### PR TITLE
Support for STM32F4 in enableSTM32SWD

### DIFF
--- a/Support/gdbtrace.init
+++ b/Support/gdbtrace.init
@@ -8,7 +8,7 @@ GDB SWO Trace Configuration Helpers
 
 Setup Device
 ------------
-enableSTM32SWD    : Enable SWO on STM32 pins
+enableSTM32SWD    : Enable SWO on STM32 pins (for STM32F4 if 4 is passed as first argument)
 prepareSWD        : Prepare SWD output in specified format
 enableSTM32TRACE  : Enable TRACE on STM32 pins
 prepareTRACE      : Prepare TRACE output in specified format
@@ -32,7 +32,7 @@ dwtCycEna         : Enable or disable CYCCNT
 Configure ITM
 -------------
 ITMId             : Set the ITM ID for this device
-ITMGTSFreq        : Set Global Timestamp frequency 
+ITMGTSFreq        : Set Global Timestamp frequency
 ITMTSPrescale     : Set Timestamp Prescale
 ITMSWDEna         : TS counter uses Processor Clock, or clock from TPIU Interface
 ITMTXEna          : Control if DWT packets are forwarded to the ITM
@@ -46,12 +46,33 @@ end
 # ====================================================================
 # ====================================================================
 define enableSTM32SWD
-  # RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
-  set *0x40021018 |= 1
-  #  AFIO->MAPR |= (2 << 24); // Disable JTAG to release TRACESWO
-  set *0x40010004 |= 0x2000000
-  #  DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
-  set *0xE0042004 |= 0x20 
+  set $tgt=1
+  if $argc >= 1
+    set $tgt = $arg0
+  end
+  if ($tgt==4)
+    # STM32F4 variant.
+    # Enable AHB1ENR
+    set *0x40023830 |= 0x02
+    # Set MODER for PB3
+    set *0x40020400 &= ~(0x000000C0)
+    set *0x40020400 |= 0x00000080
+    # Set max (100MHz) speed in OSPEEDR
+    set *0x40020408 |= 0x000000C0
+    # No pull up or down in PUPDR
+    set *0x4002040C &= ~(0x000000C0)
+    # Set AF0 (==TRACESWO) in AFRL
+    set *0x40020420 &= ~(0x0000F000)
+  else
+    # STM32F1 variant.
+    # RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+    set *0x40021018 |= 1
+    # AFIO->MAPR |= (2 << 24); // Disable JTAG to release TRACESWO
+    set *0x40010004 |= 0x2000000
+  end
+  # Common initialisation.
+  # DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
+  set *0xE0042004 |= 0x20
 end
 document enableSTM32SWD
 enableSTM32SWD Configure output pin on STM32 for SWO use.
@@ -126,7 +147,7 @@ define prepareSWD
   set $speed=2250000
   set $useTPIU=1
   set $useMan=0
-  
+
   if $argc >= 1
     set $clockspeed = $arg0
   end
@@ -145,11 +166,11 @@ define prepareSWD
 
   # Make sure we can get to everything
   set *0xe0000fb0 = 0xc5acce55
-  set *0xe0041fb0 = 0xc5acce55  
+  set *0xe0041fb0 = 0xc5acce55
 
   # Enable DEMCR TRCENA
   set *0xE000EDFC=(1<<24)
-  
+
   if ($useMan==0)
     # Use Async mode pin protocol
     set *0xE00400F0 = 2
@@ -455,7 +476,7 @@ define ITMTXEna
     end
   end
 end
-document ITMSWOEna
+document ITMTXEna
 ITMTXEna <0|1> 0-DWT packets are not forwarded to the ITM
                1-DWT packets are output to the ITM
 end


### PR DESCRIPTION
STM32F479 have TRACESWO output on GPIOB3 which need to be configured correctly before working.

Also fix ITMTXEna function documentation error.
