### PR TITLE
Allow configure high speed on recent Linux kernel that support BOTHER in termios.

### DIFF
--- a/Inc/generics.h
+++ b/Inc/generics.h
@@ -24,7 +24,11 @@
 #include <limits.h>
 #include <stdint.h>
 
+#if defined LINUX
+#define EOL "\n"
+#else
 #define EOL "\n\r"
+#endif
 
 // ====================================================================================================
 enum verbLevel {V_ERROR, V_WARN, V_INFO, V_DEBUG};


### PR DESCRIPTION
Current implementation don't allow setting speed more than 4M but Hi-Speed FTDI USB Serial converter (and may be other) allow use of any value in `c_(i|o)speed` fields of termios2 structure.

According to Linux kernel headers, a `BOTHER` baud setting is available (see <asm-generic/termbits.h>) and permit using any value for `c_(i|o)speed`.

This change may allow user to set baudrate up to 12M with compatible USB Serial converter by bypassing the GLIBC `tc(s|g)etattr` which don't work correctly.
