### PR TITLE
orbdump: fix segfault on -v option

### DIFF
--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -219,7 +219,7 @@ int _processOptions( int argc, char *argv[] )
 {
     int c;
 
-    while ( ( c = getopt ( argc, argv, "hti:l:no:p:s:vw" ) ) != -1 )
+    while ( ( c = getopt ( argc, argv, "hti:l:no:p:s:v:w" ) ) != -1 )
         switch ( c )
         {
             case 'o':


### PR DESCRIPTION
Missing argument.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>