### PR TITLE
Add travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+env:
+  - WITH_FPGA=0
+  - WITH_FPGA=1
+script:
+  - make
+
+addons:
+  apt:
+    packages:
+    - libusb-1.0-0-dev
+    - binutils-dev
+    - libelf-dev
+    - libiberty-dev
+
+before_install:
+  - if [ "$WITH_FPGA" = 1 ]; then sudo apt install -y libftdi1-dev; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![Screenshot](https://raw.githubusercontent.com/orbcode/orbuculum/master/Docs/title.png)
+* Build status master: [![Build Status: master](https://travis-ci.com/orbcode/orbuculum.svg?branch=master)](https://travis-ci.com/orbcode/orbuculum)
+* Build status, Devel branch: [![Build Status: Devel](https://travis-ci.com/orbcode/orbuculum.svg?branch=Devel)](https://travis-ci.com/orbcode/orbuculum)
 
 * Latest Changes:
 


### PR DESCRIPTION
Adds travis build of at least the WITH_FPGA variants.

This stack is against Devel, but can easily be rebased to master as well.  Included is a tweak to the readme that shows the build status.  I've not configured any notifications or anything.

Example of how it looks like: https://github.com/karlp/orbuculum (for the readme)
and example of the currently failing split builds on Devel: https://travis-ci.com/github/karlp/orbuculum/builds/183595382
