### PR TITLE
orbtop: don't set serial speed if there is none

### DIFF
--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -1414,9 +1414,12 @@ int main( int argc, char *argv[] )
                 usleep( 1000000 );
             }
 
-            if ( ( ret = _setSerialConfig ( sourcefd, options.speed ) ) < 0 )
+            if ( options.speed )
             {
-                genericsExit( ret, "setSerialConfig failed" EOL );
+                if ( ( ret = _setSerialConfig ( sourcefd, options.speed ) ) < 0 )
+                {
+                    genericsExit( ret, "setSerialConfig failed" EOL );
+                }
             }
         }
         else


### PR DESCRIPTION
This leaves the (dubious) inclusion of serial support in orbtop, but at
_least_ avoids calling it if no serial speed was specified, allowing
"normal" usage with an orbuculum server to function again.

Fixes: https://github.com/orbcode/orbuculum/issues/34
Signed-off-by: Karl Palsson <karlp@tweak.net.au>