### PR TITLE
orbstat: fix -v arg

### DIFF
--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -220,7 +220,7 @@ int _processOptions( int argc, char *argv[] )
 {
     int c;
 
-    while ( ( c = getopt ( argc, argv, "hti:l:no:p:s:vw" ) ) != -1 )
+    while ( ( c = getopt ( argc, argv, "hti:l:no:p:s:v:w" ) ) != -1 )
         switch ( c )
         {
             case 'o':

--- a/Src/orbstat.c
+++ b/Src/orbstat.c
@@ -825,7 +825,7 @@ int _processOptions( int argc, char *argv[] )
 {
     int c;
 
-    while ( ( c = getopt ( argc, argv, "d:e:f:g:hi:lnp:s:tvy:z:" ) ) != -1 )
+    while ( ( c = getopt ( argc, argv, "d:e:f:g:hi:lnp:s:tv:y:z:" ) ) != -1 )
 
         switch ( c )
         {


### PR DESCRIPTION
Was core dumping with -v on the null arg pointer.