### PR TITLE
Fix build on OS X

### DIFF
--- a/Src/nwclient.c
+++ b/Src/nwclient.c
@@ -16,7 +16,6 @@
 #include <assert.h>
 #include <strings.h>
 #include <stdio.h>
-#include <linux/tcp.h>
 #include "generics.h"
 #include "nwclient.h"
 

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -5,6 +5,7 @@
  *
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
On OSX, stdio.h is needed for perror(); linux/tcp.h doesn't exist, but removing it
allows the build to work on OSX and doesn't break it on Linux.