### PR TITLE
support: add udev rules file

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ The command line to build the Orbuculum tool suite is;
 
 You may need to change the paths to your libusb files, depending on how well your build environment is set up.
 
+Permissions and Access
+----------------------
+A udev rules files is included in ```Support/60-orbcode.rules```
+Install this to ```/etc/udev/rules.d``` to grant access to orbcode hardware, if required.
+
 Building on OSX
 ===============
 

--- a/Support/60-orbcode.rules
+++ b/Support/60-orbcode.rules
@@ -1,0 +1,12 @@
+# Copy this to /etc/udev/rules.d
+# use "udevadm control --reload" if needed
+
+ACTION!="add|change", GOTO="orb_rules_end"
+SUBSYSTEM!="usb|tty|hidraw", GOTO="orb_rules_end"
+
+# Orbrace mini in bootloader mode
+ATTRS{idVendor}=="1209" ATTRS{idProduct}=="3442", GROUP="plugdev", TAG+="uaccess"
+# Orbrace mini
+ATTRS{idVendor}=="1209" ATTRS{idProduct}=="3443", GROUP="plugdev", TAG+="uaccess"
+
+LABEL="orb_rules_end"


### PR DESCRIPTION
Provide a udev rules file that matches on vid/pid, so that we can grant
access to the entire device.  Default openocd rules won't recognise
orbtrace as cmsis-dap, as we have the tag on the interface, not the
product, and we need to grant access to the rest of the device as well,
not just the cmsis-dap interface.

Signed-off-by: Karl Palsson <karlp@etactica.com>