### PR TITLE
Orbuculum->orbtop/orbcat stream abstraction.

### DIFF
--- a/Inc/dataStream.h
+++ b/Inc/dataStream.h
@@ -1,0 +1,32 @@
+#ifndef _DATA_STREAM_H_
+#define _DATA_STREAM_H_
+
+#include <stddef.h>
+#include <sys/time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum ReceiveResult
+{
+    RECEIVE_RESULT_OK,
+    RECEIVE_RESULT_TIMEOUT,
+    RECEIVE_RESULT_EOF,
+    RECEIVE_RESULT_ERROR,
+};
+
+struct DataStream
+{
+    enum ReceiveResult (*receive)(struct DataStream* stream, void* buffer, size_t bufferSize, struct timeval* timeout, size_t* receivedSize);
+    void (*close)(struct DataStream* stream);
+};
+
+struct DataStream* dataStreamCreateSocket(const char* server, int port);
+struct DataStream* dataStreamCreateFile(const char* file);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,12 @@ endif
 # ==========
 
 ORBLIB_CFILES = $(App_DIR)/itmDecoder.c $(App_DIR)/tpiuDecoder.c $(App_DIR)/msgDecoder.c $(App_DIR)/msgSeq.c $(App_DIR)/traceDecoder.c
+ORBLIB_CFILES = $(App_DIR)/itmDecoder.c $(App_DIR)/tpiuDecoder.c $(App_DIR)/msgDecoder.c $(App_DIR)/msgSeq.c $(App_DIR)/traceDecoder.c $(App_DIR)/dataStream_socket.c 
+
+ifdef WINDOWS
+else
+	ORBLIB_CFILES += $(App_DIR)/dataStream_file_posix.c
+endif
 
 ORBUCULUM_CFILES  = $(App_DIR)/$(ORBUCULUM).c $(App_DIR)/nwclient.c
 ORBFIFO_CFILES    = $(App_DIR)/$(ORBFIFO).c $(App_DIR)/filewriter.c $(App_DIR)/itmfifos.c

--- a/Src/dataStream_file_posix.c
+++ b/Src/dataStream_file_posix.c
@@ -1,0 +1,84 @@
+#include "dataStream.h"
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "generics.h"
+
+
+struct PosixFileDataStream
+{
+    struct DataStream base;
+    int file;
+};
+
+#define SELF(stream) ((struct PosixFileDataStream*)(stream))
+
+static enum ReceiveResult posixFileStreamReceive(struct DataStream* stream, void* buffer, size_t bufferSize, struct timeval* timeout, size_t* receivedSize)
+{
+    struct PosixFileDataStream* self = SELF(stream);
+    fd_set readFd;
+    FD_ZERO(&readFd);
+    FD_SET(self->file, &readFd);
+
+    int r = select(self->file + 1, &readFd, NULL, NULL, timeout);
+
+    if(r < 0)
+    {
+        return RECEIVE_RESULT_ERROR;
+    }
+
+    if(r == 0)
+    {
+        *receivedSize = 0;
+        return RECEIVE_RESULT_TIMEOUT;
+    }
+
+    *receivedSize = read(self->file, buffer, bufferSize);
+    if(*receivedSize == 0)
+    {
+        return RECEIVE_RESULT_EOF;
+    }
+
+    return RECEIVE_RESULT_OK;
+}
+
+static void posixFileStreamClose(struct DataStream* stream)
+{
+    struct PosixFileDataStream* self = SELF(stream);
+    close(self->file);
+}
+
+static int posixFileStreamCreate(const char* file)
+{
+    int f = open(file, O_RDONLY);
+
+    if (f < 0)
+    {
+        genericsExit( -4, "Can't open file %s" EOL, file );
+    }
+
+    return f;
+}
+
+struct DataStream* dataStreamCreateFile(const char* file)
+{
+    struct PosixFileDataStream* stream = SELF(calloc(1, sizeof(struct PosixFileDataStream)));
+
+    if(stream == NULL)
+    {
+        return NULL;
+    }
+
+    stream->base.receive = posixFileStreamReceive;
+    stream->base.close = posixFileStreamClose;
+    stream->file = posixFileStreamCreate(file);
+
+    if(stream->file == -1)
+    {
+        free(stream);
+        return NULL;
+    }
+
+    return &stream->base;
+}

--- a/Src/dataStream_socket.c
+++ b/Src/dataStream_socket.c
@@ -50,7 +50,14 @@ static enum ReceiveResult socketStreamReceive(struct DataStream* stream, void* b
         return RECEIVE_RESULT_TIMEOUT;
     }
 
-    *receivedSize = recv(self->socket, buffer, bufferSize, 0);
+    ssize_t result = recv(self->socket, buffer, bufferSize, 0);
+    if(result <= 0)
+    {
+        // report connection broken as error
+        return RECEIVE_RESULT_ERROR; 
+    }
+
+    *receivedSize = result;
     return RECEIVE_RESULT_OK;
 }
 

--- a/Src/dataStream_socket.c
+++ b/Src/dataStream_socket.c
@@ -1,0 +1,127 @@
+#include "dataStream.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef WIN32
+    #include <winsock2.h>
+#else
+    #include <sys/ioctl.h>
+    #include <netinet/in.h>
+    #include <netdb.h>
+#endif
+
+#include "generics.h"
+
+
+struct SocketDataStream
+{
+    struct DataStream base;
+    int socket;
+};
+
+#define SELF(stream) ((struct SocketDataStream*)(stream))
+
+#ifdef WIN32
+    // https://stackoverflow.com/a/14388707/995351
+    #define SO_REUSEPORT SO_REUSEADDR
+#endif
+
+static enum ReceiveResult socketStreamReceive(struct DataStream* stream, void* buffer, size_t bufferSize, struct timeval* timeout, size_t* receivedSize)
+{
+    struct SocketDataStream* self = SELF(stream);
+
+    *receivedSize = 0;
+
+    fd_set readFd;
+    FD_ZERO(&readFd);
+    FD_SET(self->socket, &readFd);
+
+    int r = select(self->socket + 1, &readFd, NULL, NULL, timeout);
+
+    if(r < 0)
+    {
+        return RECEIVE_RESULT_ERROR;
+    }
+
+    if(r == 0)
+    {
+        *receivedSize = 0;
+        return RECEIVE_RESULT_TIMEOUT;
+    }
+
+    *receivedSize = recv(self->socket, buffer, bufferSize, 0);
+    return RECEIVE_RESULT_OK;
+}
+
+static void socketStreamClose(struct DataStream* stream)
+{
+    struct SocketDataStream* self = SELF(stream);
+    close(self->socket);
+}
+
+static int socketStreamCreate(const char* server, int port)
+{
+    #ifdef WIN32
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2, 2), &wsaData);
+    #endif
+
+    int sockfd = socket( AF_INET, SOCK_STREAM, IPPROTO_TCP );
+
+    int flag = 1;
+    setsockopt( sockfd, SOL_SOCKET, SO_REUSEPORT, (const void*)&flag, sizeof( flag ) );
+
+    if ( sockfd < 0 )
+    {
+        genericsReport( V_ERROR, "Error creating socket" EOL );
+        return -1;
+    }
+
+    struct hostent* serverEnt = gethostbyname( server );
+    if ( !serverEnt )
+    {
+        close(sockfd);
+        genericsReport( V_ERROR, "Cannot find host" EOL );
+        return -1;
+    }
+
+    struct sockaddr_in serv_addr;
+    /* Now open the network connection */
+    memset( &serv_addr, 0, sizeof( serv_addr ) );
+
+    serv_addr.sin_family = AF_INET;
+    memcpy(&serv_addr.sin_addr.s_addr, serverEnt->h_addr, serverEnt->h_length);
+    serv_addr.sin_port = htons(port);
+
+    if ( connect( sockfd, ( struct sockaddr * ) &serv_addr, sizeof( serv_addr ) ) < 0 )
+    {
+        close(sockfd);
+        genericsReport( V_ERROR, "Could not connect" EOL );
+        return -1;
+    }
+
+    return sockfd;
+}
+
+struct DataStream* dataStreamCreateSocket(const char* server, int port)
+{
+    struct SocketDataStream* stream = SELF(calloc(1, sizeof(struct SocketDataStream)));
+
+    if(stream == NULL)
+    {
+        return NULL;
+    }
+
+    stream->base.receive = socketStreamReceive;
+    stream->base.close = socketStreamClose;
+    stream->socket = socketStreamCreate(server, port);
+
+    if(stream->socket == -1)
+    {
+        free(stream);
+        return NULL;
+    }
+
+    return &stream->base;
+}


### PR DESCRIPTION
Single structure with function pointers provides API for presentation tools to receive data. Opening data stream is packet into separate functions. Different types of stream can subclass base interface (C-style inheritance) to store stream-specific data. Additonaly per platform implementation can be selected by compiling proper file.

Tested with Linux and Windows (not included in this PR) implementation of socket and file data stream.

Tests summary:

| Data stream                        | Windows/orbcat     | Windows/orbtop         | Linux/orbcat       | Linux/orbtop       |
|------------------------------------|--------------------|------------------------|--------------------|--------------------|
| TCP Socket                         | :white_check_mark: | :white_check_mark:     | :white_check_mark: | :white_check_mark: |
| Recorded file                      | :white_check_mark: | :white_check_mark:     | :white_check_mark: | :white_check_mark: |
| Recorded file (+ `-e` in `orbcat`) | :white_check_mark: | -                      | :white_check_mark: | -                  |
| Live file                          | :white_check_mark: | :white_check_mark: (1) | :white_check_mark: | :white_check_mark:  |

Notes:
(1) - `orbtop` occiasionally reported `Unknown TPIU channel`. More investigation is required but I consider reading from live file on Windows to be an unusual scenario.

I'm not fixed on naming new interface 'data stream', so if you have better name there is no problem in changing that. 