### PR TITLE
Run Windows build GitHub action for pull requests

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   win64:
     runs-on: windows-latest
-    if: github.event_name == 'push'
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
I'm not an expert when it comes to GitHub actions and current workflow on Devel does not trigger Windows build on pull requests, hopefull this change will fix that