### PR TITLE
libusb_dev_mem_alloc is not required to allocate buffer, fallback to malloc

### DIFF
--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -951,6 +951,11 @@ static int _usbFeeder( struct RunTime *r )
             r->rawBlock[t].usbtfr = libusb_alloc_transfer( 0 );
             r->rawBlock[t].buffer = libusb_dev_mem_alloc( handle, TRANSFER_SIZE );
 
+            if ( r->rawBlock[t].buffer == NULL )
+            {
+                r->rawBlock[t].buffer = malloc( TRANSFER_SIZE );
+            }
+
             libusb_fill_bulk_transfer ( r->rawBlock[t].usbtfr, handle, ep,
                                         r->rawBlock[t].buffer,
                                         TRANSFER_SIZE,


### PR DESCRIPTION
According to libusb documentation `libusb_dev_mem_alloc` might not allocate buffer.

>  Many systems do not support such zero-copy and will always return NULL.

When libusb is not able to provide buffer, fallback to `malloc`.



