### PR TITLE
Feature: longopts and version info

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,6 +7,7 @@ Tom Keddie             github@bronwenandtom.com
 Francois Killeen       killeenfrancois@gmail.com
 Andrew Kohlsmith
 Devan Lai              devan.lai@gmail.com                     *3
+Rachel Mant            git@dragonmux.network
 Dave Marples           dave@marples.net                        *4
 David Piegdon          david@piegdon.de                        *5
 Karl Palsson           karlp@tweak.net.au                      *6

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ get_version:
 	$(Q)echo "#define GIT_BRANCH \""`git rev-parse --abbrev-ref HEAD`\" >> $(OLOC)/$(GIT_HASH_FILENAME)
 	$(Q)echo "#define BUILD_DATE \""`date "+%Y-%m-%d %H:%M:%S%z"`\" >> $(OLOC)/$(GIT_HASH_FILENAME)
 	$(Q)echo "#define GIT_DIRTY " $(DIRTY) >> $(OLOC)/$(GIT_HASH_FILENAME)
+	$(Q)echo "#define GIT_DESCRIBE \"`git describe --tags --always --dirty`\"" >> $(OLOC)/$(GIT_HASH_FILENAME)
 
 $(OLOC)/%.o : %.c
 	$(Q)mkdir -p $(basename $@)

--- a/Src/orbcat.c
+++ b/Src/orbcat.c
@@ -362,7 +362,7 @@ struct option longOptions[] =
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
-int _processOptions( int argc, char *argv[] )
+bool _processOptions( int argc, char *argv[] )
 
 {
     int c, optionIndex = 0;

--- a/Src/orbcat.c
+++ b/Src/orbcat.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <assert.h>
 #include <inttypes.h>
+#include <getopt.h>
 
 #include "nw.h"
 #include "git_version_info.h"
@@ -330,26 +331,39 @@ void _printHelp( char *progName )
 
 {
     fprintf( stdout, "Usage: %s [options]" EOL, progName );
-    fprintf( stdout, "      -c: <Number>,<Format> of channel to add into output stream (repeat per channel)" EOL );
-    fprintf( stdout, "      -e: Terminate when the file/socket ends/is closed, or attempt to wait for more / reconnect" EOL );
-    fprintf( stdout, "      -f: <filename> Take input from specified file" EOL );
-    fprintf( stdout, "      -h: This help" EOL );
-    fprintf( stdout, "      -n: Enforce sync requirement for ITM (i.e. ITM needsd to issue syncs)" EOL );
-    fprintf( stdout, "      -s: <Server>:<Port> to use" EOL );
-    fprintf( stdout, "      -t <channel>: Use TPIU decoder on specified channel (normally 1)" EOL );
-    fprintf( stdout, "      -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
+    fprintf( stdout, "    -c, --channel:      <Number>,<Format> of channel to add into output stream (repeat per channel)" EOL );
+    fprintf( stdout, "    -e, --eof:          Terminate when the file/socket ends/is closed, or attempt to wait for more / reconnect" EOL );
+    fprintf( stdout, "    -f, --input-file:   <filename> Take input from specified file" EOL );
+    fprintf( stdout, "    -h, --help:         This help" EOL );
+    fprintf( stdout, "    -n, --itm-sync:     Enforce sync requirement for ITM (i.e. ITM needsd to issue syncs)" EOL );
+    fprintf( stdout, "    -s, --server:       <Server>:<Port> to use" EOL );
+    fprintf( stdout, "    -t, --tpiu:         <channel>: Use TPIU decoder on specified channel (normally 1)" EOL );
+    fprintf( stdout, "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
 }
+// ====================================================================================================
+struct option longOptions[] =
+{
+    {"channel", required_argument, NULL, 'c'},
+    {"eof", no_argument, NULL, 'e'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"help", no_argument, NULL, 'h'},
+    {"itm-sync", no_argument, NULL, 'n'},
+    {"server", required_argument, NULL, 's'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"verbose", required_argument, NULL, 'v'},
+    {NULL, no_argument, NULL, 0}
+};
 // ====================================================================================================
 int _processOptions( int argc, char *argv[] )
 
 {
-    int c;
+    int c, optionIndex = 0;
     char *chanConfig;
     unsigned int chan;
     char *chanIndex;
 #define DELIMITER ','
 
-    while ( ( c = getopt ( argc, argv, "c:ef:hns:t:v:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "c:ef:hns:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------

--- a/Src/orbcat.c
+++ b/Src/orbcat.c
@@ -339,6 +339,13 @@ void _printHelp( char *progName )
     fprintf( stdout, "    -s, --server:       <Server>:<Port> to use" EOL );
     fprintf( stdout, "    -t, --tpiu:         <channel>: Use TPIU decoder on specified channel (normally 1)" EOL );
     fprintf( stdout, "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    fprintf( stdout, "    -V, --version:      Print version and exit" EOL );
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbcat version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -351,6 +358,7 @@ struct option longOptions[] =
     {"server", required_argument, NULL, 's'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
@@ -363,12 +371,17 @@ int _processOptions( int argc, char *argv[] )
     char *chanIndex;
 #define DELIMITER ','
 
-    while ( ( c = getopt_long ( argc, argv, "c:ef:hns:t:v:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "c:ef:hVns:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
             case 'h':
                 _printHelp( argv[0] );
+                return false;
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
                 return false;
 
             // ------------------------------------

--- a/Src/orbcat.c
+++ b/Src/orbcat.c
@@ -327,7 +327,7 @@ void _protocolPump( uint8_t c )
     }
 }
 // ====================================================================================================
-void _printHelp( char *progName )
+void _printHelp( const char *const progName )
 
 {
     fprintf( stdout, "Usage: %s [options]" EOL, progName );

--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -154,7 +154,7 @@ void _protocolPump( uint8_t c )
     }
 }
 // ====================================================================================================
-void _printHelp( char *progName )
+void _printHelp( const char *const progName )
 
 {
     fprintf( stdout, "Usage: %s [options]" EOL, progName );

--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -12,6 +12,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <getopt.h>
 
 #include "generics.h"
 #include "uthash.h"
@@ -157,23 +158,37 @@ void _printHelp( char *progName )
 
 {
     fprintf( stdout, "Usage: %s [options]" EOL, progName );
-    fprintf( stdout, "       -h: This help" EOL );
-    fprintf( stdout, "       -l: <timelen> Length of time in ms to record from point of acheiving sync (defaults to %dmS)" EOL, options.timelen );
-    fprintf( stdout, "       -n: Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
-    fprintf( stdout, "       -o: <filename> to be used for dump file (defaults to %s)" EOL, options.outfile );
-    fprintf( stdout, "       -p: <Port> to use" EOL );
-    fprintf( stdout, "       -s: <Server> to use" EOL );
-    fprintf( stdout, "       -t: <channel> Use TPIU decoder on specified channel, normally 1" EOL );
-    fprintf( stdout, "       -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
-    fprintf( stdout, "       -w: Write syncronously to the output file after every packet" EOL );
+    fprintf( stdout, "    -h, --help:         This help" EOL );
+    fprintf( stdout, "    -l, --length:       <timelen> Length of time in ms to record from point of acheiving sync (defaults to %dmS)" EOL, options.timelen );
+    fprintf( stdout, "    -n, --itm-sync:     Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
+    fprintf( stdout, "    -o, --output-file:  <filename> to be used for dump file (defaults to %s)" EOL, options.outfile );
+    fprintf( stdout, "    -p, --port:         <Port> to use" EOL );
+    fprintf( stdout, "    -s, --server:       <Server> to use" EOL );
+    fprintf( stdout, "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
+    fprintf( stdout, "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    fprintf( stdout, "    -w, --sync-write:   Write syncronously to the output file after every packet" EOL );
 }
+// ====================================================================================================
+struct option longOptions[] =
+{
+    {"help", no_argument, NULL, 'h'},
+    {"length", required_argument, NULL, 'l'},
+    {"itm-sync", no_argument, NULL, 'n'},
+    {"output-file", required_argument, NULL, 'o'},
+    {"port", required_argument, NULL, 'p'},
+    {"server", required_argument, NULL, 's'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"verbose", required_argument, NULL, 'v'},
+    {"sync-write", no_argument, NULL, 'w'},
+    {NULL, no_argument, NULL, 0}
+};
 // ====================================================================================================
 int _processOptions( int argc, char *argv[] )
 
 {
-    int c;
+    int c, optionIndex = 0;
 
-    while ( ( c = getopt ( argc, argv, "hl:no:p:s:t:v:w" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "hl:no:p:s:t:v:w", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             case 'o':

--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -166,7 +166,14 @@ void _printHelp( char *progName )
     fprintf( stdout, "    -s, --server:       <Server> to use" EOL );
     fprintf( stdout, "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
     fprintf( stdout, "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    fprintf( stdout, "    -V, --version:      Print version and exit" EOL );
     fprintf( stdout, "    -w, --sync-write:   Write syncronously to the output file after every packet" EOL );
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbdump version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -179,6 +186,7 @@ struct option longOptions[] =
     {"server", required_argument, NULL, 's'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {"sync-write", no_argument, NULL, 'w'},
     {NULL, no_argument, NULL, 0}
 };
@@ -188,7 +196,7 @@ int _processOptions( int argc, char *argv[] )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "hl:no:p:s:t:v:w", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "hVl:no:p:s:t:v:w", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             case 'o':
@@ -227,6 +235,11 @@ int _processOptions( int argc, char *argv[] )
 
             case 'h':
                 _printHelp( argv[0] );
+                return false;
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
                 return false;
 
             case '?':

--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -191,7 +191,7 @@ struct option longOptions[] =
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
-int _processOptions( int argc, char *argv[] )
+bool _processOptions( int argc, char *argv[] )
 
 {
     int c, optionIndex = 0;

--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -157,17 +157,17 @@ void _protocolPump( uint8_t c )
 void _printHelp( const char *const progName )
 
 {
-    fprintf( stdout, "Usage: %s [options]" EOL, progName );
-    fprintf( stdout, "    -h, --help:         This help" EOL );
-    fprintf( stdout, "    -l, --length:       <timelen> Length of time in ms to record from point of acheiving sync (defaults to %dmS)" EOL, options.timelen );
-    fprintf( stdout, "    -n, --itm-sync:     Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
-    fprintf( stdout, "    -o, --output-file:  <filename> to be used for dump file (defaults to %s)" EOL, options.outfile );
-    fprintf( stdout, "    -p, --port:         <Port> to use" EOL );
-    fprintf( stdout, "    -s, --server:       <Server> to use" EOL );
-    fprintf( stdout, "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
-    fprintf( stdout, "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
-    fprintf( stdout, "    -V, --version:      Print version and exit" EOL );
-    fprintf( stdout, "    -w, --sync-write:   Write syncronously to the output file after every packet" EOL );
+    genericsPrintf( "Usage: %s [options]" EOL, progName );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -l, --length:       <timelen> Length of time in ms to record from point of acheiving sync (defaults to %dmS)" EOL, options.timelen );
+    genericsPrintf( "    -n, --itm-sync:     Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
+    genericsPrintf( "    -o, --output-file:  <filename> to be used for dump file (defaults to %s)" EOL, options.outfile );
+    genericsPrintf( "    -p, --port:         <Port> to use" EOL );
+    genericsPrintf( "    -s, --server:       <Server> to use" EOL );
+    genericsPrintf( "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
+    genericsPrintf( "    -w, --sync-write:   Write syncronously to the output file after every packet" EOL );
 }
 // ====================================================================================================
 void _printVersion( void )

--- a/Src/orbfifo.c
+++ b/Src/orbfifo.c
@@ -110,7 +110,7 @@ struct option longOptions[] =
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
-static int _processOptions( int argc, char *argv[] )
+static bool _processOptions( int argc, char *argv[] )
 
 {
     int c, optionIndex = 0;

--- a/Src/orbfifo.c
+++ b/Src/orbfifo.c
@@ -76,7 +76,7 @@ static void _intHandler( int sig )
 static void _printHelp( char *progName )
 
 {
-    genericsPrintf( "Usage: %s [Options]" EOL, progName );
+    genericsPrintf( "Usage: %s [options]" EOL, progName );
     genericsPrintf( "    -b, --basedir:      <basedir> for channels" EOL );
     genericsPrintf( "    -c, --channel:      <Number>,<Name>,<Format> of channel to populate (repeat per channel)" EOL );
     genericsPrintf( "    -e, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
@@ -85,7 +85,7 @@ static void _printHelp( char *progName )
     genericsPrintf( "    -P, --permanent:    Create permanent files rather than fifos" EOL );
     genericsPrintf( "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
-    genericsPrintf( "    -w, --writer-path:  <path> Enable filewriter functionality using specified base path" EOL );
+    genericsPrintf( "    -W, --writer-path:  <path> Enable filewriter functionality using specified base path" EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -98,7 +98,7 @@ struct option longOptions[] =
     {"permanent", no_argument, NULL, 'P'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
-    {"writer-path", required_argument, NULL, 'w'},
+    {"writer-path", required_argument, NULL, 'W'},
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
@@ -166,7 +166,7 @@ static int _processOptions( int argc, char *argv[] )
 
             // ------------------------------------
 
-            case 'w':
+            case 'W':
                 options.filewriter = true;
                 options.fwbasedir = optarg;
                 break;

--- a/Src/orbfifo.c
+++ b/Src/orbfifo.c
@@ -85,7 +85,14 @@ static void _printHelp( char *progName )
     genericsPrintf( "    -P, --permanent:    Create permanent files rather than fifos" EOL );
     genericsPrintf( "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
     genericsPrintf( "    -W, --writer-path:  <path> Enable filewriter functionality using specified base path" EOL );
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbfifo version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -98,6 +105,7 @@ struct option longOptions[] =
     {"permanent", no_argument, NULL, 'P'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {"writer-path", required_argument, NULL, 'W'},
     {NULL, no_argument, NULL, 0}
 };
@@ -113,7 +121,7 @@ static int _processOptions( int argc, char *argv[] )
     uint chan;
     char *chanIndex;
 
-    while ( ( c = getopt_long ( argc, argv, "b:c:ef:hn:Pt:v:w:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "b:c:ef:hVn:Pt:v:w:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -137,6 +145,11 @@ static int _processOptions( int argc, char *argv[] )
 
             case 'h':
                 _printHelp( argv[0] );
+                return false;
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
                 return false;
 
             // ------------------------------------

--- a/Src/orbfifo.c
+++ b/Src/orbfifo.c
@@ -73,7 +73,7 @@ static void _intHandler( int sig )
     exit( 0 );
 }
 // ====================================================================================================
-static void _printHelp( char *progName )
+static void _printHelp( const char *const progName )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, progName );

--- a/Src/orbfifo.c
+++ b/Src/orbfifo.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <assert.h>
 #include <signal.h>
+#include <getopt.h>
 
 #include "git_version_info.h"
 #include "generics.h"
@@ -76,21 +77,35 @@ static void _printHelp( char *progName )
 
 {
     genericsPrintf( "Usage: %s [Options]" EOL, progName );
-    genericsPrintf( "       -b <basedir> for channels" EOL );
-    genericsPrintf( "       -c <Number>,<Name>,<Format> of channel to populate (repeat per channel)" EOL );
-    genericsPrintf( "       -e When reading from file, terminate at end of file rather than waiting for further input" EOL );
-    genericsPrintf( "       -f <filename> Take input from specified file" EOL );
-    genericsPrintf( "       -h This help" EOL );
-    genericsPrintf( "       -P Create permanent files rather than fifos" EOL );
-    genericsPrintf( "       -t <channel> Use TPIU decoder on specified channel (normally 1)" EOL );
-    genericsPrintf( "       -v <level> Verbose mode 0(errors)..3(debug)" EOL );
-    genericsPrintf( "       -w <path> Enable filewriter functionality using specified base path" EOL );
+    genericsPrintf( "    -b, --basedir:      <basedir> for channels" EOL );
+    genericsPrintf( "    -c, --channel:      <Number>,<Name>,<Format> of channel to populate (repeat per channel)" EOL );
+    genericsPrintf( "    -e, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -f, --input-file:   <filename> Take input from specified file" EOL );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -P, --permanent:    Create permanent files rather than fifos" EOL );
+    genericsPrintf( "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel, normally 1" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -w, --writer-path:  <path> Enable filewriter functionality using specified base path" EOL );
 }
+// ====================================================================================================
+struct option longOptions[] =
+{
+    {"basedir", required_argument, NULL, 'b'},
+    {"channel", required_argument, NULL, 'c'},
+    {"eof", no_argument, NULL, 'e'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"help", no_argument, NULL, 'h'},
+    {"permanent", no_argument, NULL, 'P'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"verbose", required_argument, NULL, 'v'},
+    {"writer-path", required_argument, NULL, 'w'},
+    {NULL, no_argument, NULL, 0}
+};
 // ====================================================================================================
 static int _processOptions( int argc, char *argv[] )
 
 {
-    int c;
+    int c, optionIndex = 0;
 #define DELIMITER ','
 
     char *chanConfig;
@@ -98,7 +113,7 @@ static int _processOptions( int argc, char *argv[] )
     uint chan;
     char *chanIndex;
 
-    while ( ( c = getopt ( argc, argv, "b:c:ef:hn:Pt:v:w:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "b:c:ef:hn:Pt:v:w:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -200,7 +200,7 @@ struct option longOptions[] =
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
-static int _processOptions( int argc, char *argv[], struct RunTime *r )
+static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 
 {
     int c, optionIndex = 0;

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <signal.h>
+#include <getopt.h>
 
 #include "git_version_info.h"
 #include "generics.h"
@@ -152,32 +153,51 @@ static void _printHelp( struct RunTime *r )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, r->progName );
-    genericsPrintf( "       -a: Do not use alternate address encoding" EOL );
-    genericsPrintf( "       -b: <Length> Length of post-mortem buffer, in KBytes (Default %d KBytes)" EOL, DEFAULT_PM_BUFLEN_K );
-    genericsPrintf( "       -c: <command> Command line for external editor (%f = filename, %l = line)" EOL );
-    genericsPrintf( "       -D: Switch off C++ symbol demangling" EOL );
-    genericsPrintf( "       -d: <String> Material to delete off front of filenames" EOL );
-    genericsPrintf( "       -e: <ElfFile> to use for symbols and source" EOL );
-    genericsPrintf( "       -E: When reading from file, terminate at end of file rather than waiting for further input" EOL );
-    genericsPrintf( "       -f <filename>: Take input from specified file" EOL );
-    genericsPrintf( "       -h: This help" EOL );
-    genericsPrintf( "       -O: <options> Options to pass directly to objdump" EOL );
-    genericsPrintf( "       -p: {ETM35|MTB} trace protocol to use, default is ETM35" EOL );
-    genericsPrintf( "       -s: <Server>:<Port> to use" EOL );
-    genericsPrintf( "       -t <channel>: Use TPIU to strip TPIU on specfied channel" EOL );
-    genericsPrintf( "       -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -a, --alt-addr-enc: Do not use alternate address encoding" EOL );
+    genericsPrintf( "    -b, --buffer-len:   <Length> Length of post-mortem buffer, in KBytes (Default %d KBytes)" EOL, DEFAULT_PM_BUFLEN_K );
+    genericsPrintf( "    -c, --editor-cmd:   <command> Command line for external editor (%f = filename, %l = line)" EOL );
+    genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
+    genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off the front of filenames" EOL );
+    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols and source" EOL );
+    genericsPrintf( "    -E, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -f, --input-file:   <filename>: Take input from specified file" EOL );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -O, --objdump-opts: <options> Options to pass directly to objdump" EOL );
+    genericsPrintf( "    -p, --trace-proto:  {ETM35|MTB} trace protocol to use, default is ETM35" EOL );
+    genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
+    genericsPrintf( "    -t, --tpiu:         <channel>: Use TPIU to strip TPIU on specfied channel" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
     genericsPrintf( EOL "(Will connect one port higher than that set in -s when TPIU is not used)" EOL );
     genericsPrintf( EOL "(this will automatically select the second output stream from orb TPIU.)" EOL );
     genericsPrintf( EOL "Environment Variables;" EOL );
     genericsPrintf( "  OBJDUMP: to use non-standard obbdump binary" EOL );
 }
 // ====================================================================================================
+struct option longOptions[] =
+{
+    {"alt-addr-enc", no_argument, NULL, 'a'},
+    {"buffer-len", required_argument, NULL, 'b'},
+    {"editor-cmd", required_argument, NULL, 'c'},
+    {"no-demangle", required_argument, NULL, 'D'},
+    {"del-prefix", required_argument, NULL, 'd'},
+    {"elf-file", required_argument, NULL, 'e'},
+    {"eof", no_argument, NULL, 'E'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"help", no_argument, NULL, 'h'},
+    {"objdump-opts", required_argument, NULL, 'O'},
+    {"trace-proto", required_argument, NULL, 'p'},
+    {"server", required_argument, NULL, 's'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"verbose", required_argument, NULL, 'v'},
+    {NULL, no_argument, NULL, 0}
+};
+// ====================================================================================================
 static int _processOptions( int argc, char *argv[], struct RunTime *r )
 
 {
-    int c;
+    int c, optionIndex = 0;
 
-    while ( ( c = getopt ( argc, argv, "ab:c:Dd:Ee:f:hO:p:s:t:v:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "ab:c:Dd:Ee:f:hO:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -149,10 +149,10 @@ static void _intHandler( int sig )
     exit( 0 );
 }
 // ====================================================================================================
-static void _printHelp( struct RunTime *r )
+static void _printHelp( const char *const progName )
 
 {
-    genericsPrintf( "Usage: %s [options]" EOL, r->progName );
+    genericsPrintf( "Usage: %s [options]" EOL, progName );
     genericsPrintf( "    -A, --alt-addr-enc: Do not use alternate address encoding" EOL );
     genericsPrintf( "    -b, --buffer-len:   <Length> Length of post-mortem buffer, in KBytes (Default %d KBytes)" EOL, DEFAULT_PM_BUFLEN_K );
     genericsPrintf( "    -C, --editor-cmd:   <command> Command line for external editor (%f = filename, %l = line)" EOL );
@@ -253,7 +253,7 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
             // ------------------------------------
 
             case 'h':
-                _printHelp( r );
+                _printHelp( r->progName );
                 return false;
 
             // ------------------------------------

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -167,10 +167,17 @@ static void _printHelp( struct RunTime *r )
     genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
     genericsPrintf( "    -t, --tpiu:         <channel>: Use TPIU to strip TPIU on specfied channel" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
     genericsPrintf( EOL "(Will connect one port higher than that set in -s when TPIU is not used)" EOL );
     genericsPrintf( EOL "(this will automatically select the second output stream from orb TPIU.)" EOL );
     genericsPrintf( EOL "Environment Variables;" EOL );
     genericsPrintf( "  OBJDUMP: to use non-standard obbdump binary" EOL );
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbmortem version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -189,6 +196,7 @@ struct option longOptions[] =
     {"server", required_argument, NULL, 's'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
@@ -197,7 +205,7 @@ static int _processOptions( int argc, char *argv[], struct RunTime *r )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "Ab:C:Dd:eE:f:hO:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "Ab:C:Dd:eE:f:hVO:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -246,6 +254,11 @@ static int _processOptions( int argc, char *argv[], struct RunTime *r )
 
             case 'h':
                 _printHelp( r );
+                return false;
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
                 return false;
 
             // ------------------------------------

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -153,13 +153,13 @@ static void _printHelp( struct RunTime *r )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, r->progName );
-    genericsPrintf( "    -a, --alt-addr-enc: Do not use alternate address encoding" EOL );
+    genericsPrintf( "    -A, --alt-addr-enc: Do not use alternate address encoding" EOL );
     genericsPrintf( "    -b, --buffer-len:   <Length> Length of post-mortem buffer, in KBytes (Default %d KBytes)" EOL, DEFAULT_PM_BUFLEN_K );
-    genericsPrintf( "    -c, --editor-cmd:   <command> Command line for external editor (%f = filename, %l = line)" EOL );
+    genericsPrintf( "    -C, --editor-cmd:   <command> Command line for external editor (%f = filename, %l = line)" EOL );
     genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
     genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off the front of filenames" EOL );
-    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols and source" EOL );
-    genericsPrintf( "    -E, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -E, --elf-file:     <ElfFile> to use for symbols and source" EOL );
+    genericsPrintf( "    -e, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
     genericsPrintf( "    -f, --input-file:   <filename>: Take input from specified file" EOL );
     genericsPrintf( "    -h, --help:         This help" EOL );
     genericsPrintf( "    -O, --objdump-opts: <options> Options to pass directly to objdump" EOL );
@@ -175,13 +175,13 @@ static void _printHelp( struct RunTime *r )
 // ====================================================================================================
 struct option longOptions[] =
 {
-    {"alt-addr-enc", no_argument, NULL, 'a'},
+    {"alt-addr-enc", no_argument, NULL, 'A'},
     {"buffer-len", required_argument, NULL, 'b'},
-    {"editor-cmd", required_argument, NULL, 'c'},
+    {"editor-cmd", required_argument, NULL, 'C'},
     {"no-demangle", required_argument, NULL, 'D'},
     {"del-prefix", required_argument, NULL, 'd'},
-    {"elf-file", required_argument, NULL, 'e'},
-    {"eof", no_argument, NULL, 'E'},
+    {"elf-file", required_argument, NULL, 'E'},
+    {"eof", no_argument, NULL, 'e'},
     {"input-file", required_argument, NULL, 'f'},
     {"help", no_argument, NULL, 'h'},
     {"objdump-opts", required_argument, NULL, 'O'},
@@ -197,11 +197,11 @@ static int _processOptions( int argc, char *argv[], struct RunTime *r )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "ab:c:Dd:Ee:f:hO:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "Ab:C:Dd:eE:f:hO:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
-            case 'a':
+            case 'A':
                 r->options->noAltAddr = true;
                 break;
 
@@ -211,7 +211,7 @@ static int _processOptions( int argc, char *argv[], struct RunTime *r )
                 break;
 
             // ------------------------------------
-            case 'c':
+            case 'C':
                 r->options->openFileCL = optarg;
                 break;
 
@@ -226,13 +226,13 @@ static int _processOptions( int argc, char *argv[], struct RunTime *r )
                 break;
 
             // ------------------------------------
-            case 'E':
+            case 'e':
                 r->options->fileTerminate = true;
                 break;
 
             // ------------------------------------
 
-            case 'e':
+            case 'E':
                 r->options->elffile = optarg;
                 break;
 

--- a/Src/orbprofile.c
+++ b/Src/orbprofile.c
@@ -468,9 +468,16 @@ static void _printHelp( struct RunTime *r )
     //genericsPrintf( "    -t, --tpiu:         <channel>: Use TPIU to strip TPIU on specfied channel (defaults to 2)" EOL );
     genericsPrintf( "    -T, --all-truncate: truncate -d material off all references (i.e. make output relative)" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
     genericsPrintf( "    -y, --graph-file:   <Filename> dotty filename for structured callgraph output" EOL );
     genericsPrintf( "    -z, --cache-file:   <Filename> profile filename for kcachegrind output" EOL );
     genericsPrintf( EOL "(Will connect one port higher than that set in -s when TPIU is not used)" EOL );
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbprofile version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -488,6 +495,7 @@ struct option longOptions[] =
     {"server", required_argument, NULL, 's'},
     {"all-truncate", no_argument, NULL, 'T'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {"graph-file", required_argument, NULL, 'y'},
     {"cache-file", required_argument, NULL, 'z'},
     {NULL, no_argument, NULL, 0}
@@ -498,7 +506,7 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "ADd:eE:f:hI:O:p:s:Tv:y:z:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "ADd:eE:f:hVI:O:p:s:Tv:y:z:", longOptions, &optionIndex ) ) != -1 )
 
         switch ( c )
         {
@@ -536,6 +544,11 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
             case 'h':
                 _printHelp( r );
                 exit( 0 );
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
+                return false;
 
             // ------------------------------------
             case 'I':

--- a/Src/orbprofile.c
+++ b/Src/orbprofile.c
@@ -15,6 +15,7 @@
 #include <semaphore.h>
 #include <pthread.h>
 #include <assert.h>
+#include <getopt.h>
 
 #include "git_version_info.h"
 #include "uthash.h"
@@ -453,31 +454,51 @@ static void _printHelp( struct RunTime *r )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, r->progName );
-    genericsPrintf( "       -a: Switch off alternate address decoding (on by default)" EOL );
-    genericsPrintf( "       -D: Switch off C++ symbol demangling" EOL );
-    genericsPrintf( "       -d: <String> Material to delete off front of filenames" EOL );
-    genericsPrintf( "       -E: When reading from file, terminate at end of file rather than waiting for further input" EOL );
-    genericsPrintf( "       -e: <ElfFile> to use for symbols" EOL );
-    genericsPrintf( "       -f <filename>: Take input from specified file" EOL );
-    genericsPrintf( "       -h: This help" EOL );
-    genericsPrintf( "       -I <Interval>: Time to sample (in mS)" EOL );
-    genericsPrintf( "       -O: <options> Options to pass directly to objdump" EOL );
-    genericsPrintf( "       -p: {ETM35|MTB} trace protocol to use, default is ETM35" EOL );
-    genericsPrintf( "       -s: <Server>:<Port> to use" EOL );
-    //genericsPrintf( "       -t <channel>: Use TPIU to strip TPIU on specfied channel (defaults to 2)" EOL );
-    genericsPrintf( "       -T: truncate -d material off all references (i.e. make output relative)" EOL );
-    genericsPrintf( "       -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
-    genericsPrintf( "       -y: <Filename> dotty filename for structured callgraph output" EOL );
-    genericsPrintf( "       -z: <Filename> profile filename for kcachegrind output" EOL );
+    genericsPrintf( "    -a, --alt-addr-enc: Switch off alternate address decoding (on by default)" EOL );
+    genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
+    genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off front of filenames" EOL );
+    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols" EOL );
+    genericsPrintf( "    -E, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -f, --input-file:   Take input from specified file" EOL );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -I, --interval:     <Interval> Time between samples (in ms)" EOL );
+    genericsPrintf( "    -O, --objdump-opts: <options> Options to pass directly to objdump" EOL );
+    genericsPrintf( "    -p, --trace-proto:  {ETM35|MTB} trace protocol to use, default is ETM35" EOL );
+    genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
+    //genericsPrintf( "    -t, --tpiu:         <channel>: Use TPIU to strip TPIU on specfied channel (defaults to 2)" EOL );
+    genericsPrintf( "    -T, --all-truncate: truncate -d material off all references (i.e. make output relative)" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -y, --graph-file:   <Filename> dotty filename for structured callgraph output" EOL );
+    genericsPrintf( "    -z, --cache-file:   <Filename> profile filename for kcachegrind output" EOL );
     genericsPrintf( EOL "(Will connect one port higher than that set in -s when TPIU is not used)" EOL );
 }
+// ====================================================================================================
+struct option longOptions[] =
+{
+    {"alt-addr-enc", no_argument, NULL, 'a'},
+    {"no-demangle", required_argument, NULL, 'D'},
+    {"del-prefix", required_argument, NULL, 'd'},
+    {"elf-file", required_argument, NULL, 'e'},
+    {"eof", no_argument, NULL, 'E'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"help", no_argument, NULL, 'h'},
+    {"interval", required_argument, NULL, 'I'},
+    {"objdump-opts", required_argument, NULL, 'O'},
+    {"trace-proto", required_argument, NULL, 'p'},
+    {"server", required_argument, NULL, 's'},
+    {"all-truncate", no_argument, NULL, 'T'},
+    {"verbose", required_argument, NULL, 'v'},
+    {"graph-file", required_argument, NULL, 'y'},
+    {"cache-file", required_argument, NULL, 'z'},
+    {NULL, no_argument, NULL, 0}
+};
 // ====================================================================================================
 static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 
 {
-    int c;
+    int c, optionIndex = 0;
 
-    while ( ( c = getopt ( argc, argv, "aDd:Ee:f:hI:O:p:s:Tv:y:z:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "aDd:Ee:f:hI:O:p:s:Tv:y:z:", longOptions, &optionIndex ) ) != -1 )
 
         switch ( c )
         {

--- a/Src/orbprofile.c
+++ b/Src/orbprofile.c
@@ -450,10 +450,10 @@ static void _intHandler( int sig )
     exit( 0 );
 }
 // ====================================================================================================
-static void _printHelp( struct RunTime *r )
+static void _printHelp( const char *const progName )
 
 {
-    genericsPrintf( "Usage: %s [options]" EOL, r->progName );
+    genericsPrintf( "Usage: %s [options]" EOL, progName );
     genericsPrintf( "    -A, --alt-addr-enc: Switch off alternate address decoding (on by default)" EOL );
     genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
     genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off front of filenames" EOL );
@@ -542,7 +542,7 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 
             // ------------------------------------
             case 'h':
-                _printHelp( r );
+                _printHelp( r->progName );
                 exit( 0 );
 
             // ------------------------------------

--- a/Src/orbprofile.c
+++ b/Src/orbprofile.c
@@ -454,11 +454,11 @@ static void _printHelp( struct RunTime *r )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, r->progName );
-    genericsPrintf( "    -a, --alt-addr-enc: Switch off alternate address decoding (on by default)" EOL );
+    genericsPrintf( "    -A, --alt-addr-enc: Switch off alternate address decoding (on by default)" EOL );
     genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
     genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off front of filenames" EOL );
-    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols" EOL );
-    genericsPrintf( "    -E, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -E, --elf-file:     <ElfFile> to use for symbols" EOL );
+    genericsPrintf( "    -e, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
     genericsPrintf( "    -f, --input-file:   Take input from specified file" EOL );
     genericsPrintf( "    -h, --help:         This help" EOL );
     genericsPrintf( "    -I, --interval:     <Interval> Time between samples (in ms)" EOL );
@@ -475,11 +475,11 @@ static void _printHelp( struct RunTime *r )
 // ====================================================================================================
 struct option longOptions[] =
 {
-    {"alt-addr-enc", no_argument, NULL, 'a'},
+    {"alt-addr-enc", no_argument, NULL, 'A'},
     {"no-demangle", required_argument, NULL, 'D'},
     {"del-prefix", required_argument, NULL, 'd'},
-    {"elf-file", required_argument, NULL, 'e'},
-    {"eof", no_argument, NULL, 'E'},
+    {"elf-file", required_argument, NULL, 'E'},
+    {"eof", no_argument, NULL, 'e'},
     {"input-file", required_argument, NULL, 'f'},
     {"help", no_argument, NULL, 'h'},
     {"interval", required_argument, NULL, 'I'},
@@ -498,12 +498,12 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "aDd:Ee:f:hI:O:p:s:Tv:y:z:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "ADd:eE:f:hI:O:p:s:Tv:y:z:", longOptions, &optionIndex ) ) != -1 )
 
         switch ( c )
         {
             // ------------------------------------
-            case 'a':
+            case 'A':
                 r->options->noaltAddr = true;
                 break;
 
@@ -518,12 +518,12 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
                 break;
 
             // ------------------------------------
-            case 'E':
+            case 'e':
                 r->options->fileTerminate = true;
                 break;
 
             // ------------------------------------
-            case 'e':
+            case 'E':
                 r->options->elffile = optarg;
                 break;
 

--- a/Src/orbstat.c
+++ b/Src/orbstat.c
@@ -16,6 +16,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <getopt.h>
 
 #include "git_version_info.h"
 #include "uthash.h"
@@ -468,32 +469,53 @@ static void _printHelp( struct RunTime *r )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, r->progName );
-    genericsPrintf( "       -D: Switch off C++ symbol demangling" EOL );
-    genericsPrintf( "       -d: <String> Material to delete off front of filenames" EOL );
-    genericsPrintf( "       -E: When reading from file, terminate at end of file rather than waiting for further input" EOL );
-    genericsPrintf( "       -e: <ElfFile> to use for symbols" EOL );
-    genericsPrintf( "       -f <filename>: Take input from specified file" EOL );
-    genericsPrintf( "       -g: <TraceChannel> for trace output (default %d)" EOL, r->options->traceChannel );
-    genericsPrintf( "       -h: This help" EOL );
-    genericsPrintf( "       -I <Interval>: Time to sample (in mS)" EOL );
-    genericsPrintf( "       -n: Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
-    genericsPrintf( "       -O: <options> Options to pass directly to objdump" EOL );
-    genericsPrintf( "       -s: <Server>:<Port> to use" EOL );
-    genericsPrintf( "       -t <channel>: Use TPIU to strip TPIU on specfied channel (defaults to 1)" EOL );
-    genericsPrintf( "       -T: truncate -d material off all references (i.e. make output relative)" EOL );
-    genericsPrintf( "       -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
-    genericsPrintf( "       -y: <Filename> dotty filename for structured callgraph output" EOL );
-    genericsPrintf( "       -z: <Filename> profile filename for kcachegrind output" EOL );
+    genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
+    genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off front of filenames" EOL );
+    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols" EOL );
+    genericsPrintf( "    -E, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -f, --input-file:   <filename>: Take input from specified file" EOL );
+    genericsPrintf( "    -g, --trace-chn:    <TraceChannel> for trace output (default %d)" EOL, r->options->traceChannel );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -I, --interval:     <Interval>: Time to sample (in mS)" EOL );
+    genericsPrintf( "    -n, --itm-sync:     Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
+    genericsPrintf( "    -O, --objdump-opts: <options> Options to pass directly to objdump" EOL );
+    genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
+    genericsPrintf( "    -t, --tpiu:         <channel>: Use TPIU to strip TPIU on specfied channel (defaults to 1)" EOL );
+    genericsPrintf( "    -T, --all-truncate: truncate -d material off all references (i.e. make output relative)" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -y, --graph-file:   <Filename> dotty filename for structured callgraph output" EOL );
+    genericsPrintf( "    -z, --cache-file:   <Filename> profile filename for kcachegrind output" EOL );
     genericsPrintf( EOL "(Will connect one port higher than that set in -s when TPIU is not used)" EOL );
 
 }
 // ====================================================================================================
+struct option longOptions[] =
+{
+    {"no-demangle", required_argument, NULL, 'D'},
+    {"del-prefix", required_argument, NULL, 'd'},
+    {"elf-file", required_argument, NULL, 'e'},
+    {"eof", no_argument, NULL, 'E'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"trace-chn", required_argument, NULL, 'g'},
+    {"help", no_argument, NULL, 'h'},
+    {"interval", required_argument, NULL, 'I'},
+    {"itm-sync", no_argument, NULL, 'n'},
+    {"objdump-opts", required_argument, NULL, 'O'},
+    {"server", required_argument, NULL, 's'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"all-truncate", no_argument, NULL, 'T'},
+    {"verbose", required_argument, NULL, 'v'},
+    {"graph-file", required_argument, NULL, 'y'},
+    {"cache-file", required_argument, NULL, 'z'},
+    {NULL, no_argument, NULL, 0}
+};
+// ====================================================================================================
 static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 
 {
-    int c;
+    int c, optionIndex = 0;
 
-    while ( ( c = getopt ( argc, argv, "Dd:Ee:f:g:hI:n:O:s:Tt:v:y:z:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "Dd:Ee:f:g:hI:n:O:s:Tt:v:y:z:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------

--- a/Src/orbstat.c
+++ b/Src/orbstat.c
@@ -483,10 +483,17 @@ static void _printHelp( struct RunTime *r )
     genericsPrintf( "    -t, --tpiu:         <channel>: Use TPIU to strip TPIU on specfied channel (defaults to 1)" EOL );
     genericsPrintf( "    -T, --all-truncate: truncate -d material off all references (i.e. make output relative)" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
     genericsPrintf( "    -y, --graph-file:   <Filename> dotty filename for structured callgraph output" EOL );
     genericsPrintf( "    -z, --cache-file:   <Filename> profile filename for kcachegrind output" EOL );
     genericsPrintf( EOL "(Will connect one port higher than that set in -s when TPIU is not used)" EOL );
 
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbstat version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -505,6 +512,7 @@ struct option longOptions[] =
     {"tpiu", required_argument, NULL, 't'},
     {"all-truncate", no_argument, NULL, 'T'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {"graph-file", required_argument, NULL, 'y'},
     {"cache-file", required_argument, NULL, 'z'},
     {NULL, no_argument, NULL, 0}
@@ -515,7 +523,7 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "Dd:Ee:f:g:hI:n:O:s:Tt:v:y:z:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "Dd:Ee:f:g:hVI:n:O:s:Tt:v:y:z:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -552,6 +560,11 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
             case 'h':
                 _printHelp( r );
                 exit( 0 );
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
+                return false;
 
             // ------------------------------------
             case 'I':

--- a/Src/orbstat.c
+++ b/Src/orbstat.c
@@ -471,8 +471,8 @@ static void _printHelp( struct RunTime *r )
     genericsPrintf( "Usage: %s [options]" EOL, r->progName );
     genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
     genericsPrintf( "    -d, --del-prefix:   <String> Material to delete off front of filenames" EOL );
-    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols" EOL );
-    genericsPrintf( "    -E, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
+    genericsPrintf( "    -E, --elf-file:     <ElfFile> to use for symbols" EOL );
+    genericsPrintf( "    -e, --eof:          When reading from file, terminate at end of file rather than waiting for further input" EOL );
     genericsPrintf( "    -f, --input-file:   <filename>: Take input from specified file" EOL );
     genericsPrintf( "    -g, --trace-chn:    <TraceChannel> for trace output (default %d)" EOL, r->options->traceChannel );
     genericsPrintf( "    -h, --help:         This help" EOL );
@@ -500,8 +500,8 @@ struct option longOptions[] =
 {
     {"no-demangle", required_argument, NULL, 'D'},
     {"del-prefix", required_argument, NULL, 'd'},
-    {"elf-file", required_argument, NULL, 'e'},
-    {"eof", no_argument, NULL, 'E'},
+    {"elf-file", required_argument, NULL, 'E'},
+    {"eof", no_argument, NULL, 'e'},
     {"input-file", required_argument, NULL, 'f'},
     {"trace-chn", required_argument, NULL, 'g'},
     {"help", no_argument, NULL, 'h'},
@@ -523,7 +523,7 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "Dd:Ee:f:g:hVI:n:O:s:Tt:v:y:z:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "Dd:eE:f:g:hVI:n:O:s:Tt:v:y:z:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -537,12 +537,12 @@ static bool _processOptions( int argc, char *argv[], struct RunTime *r )
                 break;
 
             // ------------------------------------
-            case 'E':
+            case 'e':
                 r->options->fileTerminate = true;
                 break;
 
             // ------------------------------------
-            case 'e':
+            case 'E':
                 r->options->elffile = optarg;
                 break;
 

--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -907,7 +907,7 @@ void _protocolPump( uint8_t c )
     }
 }
 // ====================================================================================================
-void _printHelp( char *progName )
+void _printHelp( const char *const progName )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, progName );
@@ -966,7 +966,7 @@ struct option longOptions[] =
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
-int _processOptions( int argc, char *argv[] )
+bool _processOptions( int argc, char *argv[] )
 
 {
     int c, optionIndex = 0;

--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -930,8 +930,15 @@ void _printHelp( char *progName )
     genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
     genericsPrintf( "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
     genericsPrintf( EOL "Environment Variables;" EOL );
     genericsPrintf( "  OBJDUMP: to use non-standard obbdump binary" EOL );
+}
+// ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "orbtop version " GIT_DESCRIBE EOL );
 }
 // ====================================================================================================
 struct option longOptions[] =
@@ -955,6 +962,7 @@ struct option longOptions[] =
     {"server", required_argument, NULL, 's'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
@@ -963,7 +971,7 @@ int _processOptions( int argc, char *argv[] )
 {
     int c, optionIndex = 0;
 
-    while ( ( c = getopt_long ( argc, argv, "c:d:DEe:f:g:hI:j:lm:nO:o:r:Rs:t:v:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "c:d:DEe:f:g:hVI:j:lm:nO:o:r:Rs:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -1083,6 +1091,11 @@ int _processOptions( int argc, char *argv[] )
             case 'h':
                 _printHelp( argv[0] );
                 return ERR;
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
+                return false;
 
             // ------------------------------------
             case '?':

--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <inttypes.h>
+#include <getopt.h>
 
 #include "cJSON.h"
 #include "generics.h"
@@ -584,7 +585,7 @@ static void _outputTop( uint32_t total, uint32_t reportLines, struct reportLine 
         q = fopen( options.logfile, "a" );
     }
 
-    fprintf( stdout, CLEAR_SCREEN );
+    genericsPrintf( CLEAR_SCREEN );
 
     if ( total )
     {
@@ -602,21 +603,21 @@ static void _outputTop( uint32_t total, uint32_t reportLines, struct reportLine 
                     dispSamples += report[n].count;
                     totPercent += percentage;
 
-                    fprintf( stdout, C_DATA "%3d.%02d%% " C_SUPPORT " %7" PRIu64 " ", percentage / 100, percentage % 100, report[n].count );
+                    genericsPrintf( C_DATA "%3d.%02d%% " C_SUPPORT " %7" PRIu64 " ", percentage / 100, percentage % 100, report[n].count );
 
 
                     if ( ( options.reportFilenames ) && ( report[n].n->fileindex != NO_FILE ) )
                     {
-                        fprintf( stdout, C_CONTEXT "%s" C_RESET "::", SymbolFilename( _r.s, report[n].n->fileindex ) );
+                        genericsPrintf( C_CONTEXT "%s" C_RESET "::", SymbolFilename( _r.s, report[n].n->fileindex ) );
                     }
 
                     if ( ( options.lineDisaggregation ) && ( report[n].n->line ) )
                     {
-                        fprintf( stdout, C_SUPPORT2 "%s" C_RESET "::" C_CONTEXT "%d" EOL, d ? d : SymbolFunction( _r.s, report[n].n->functionindex ), report[n].n->line );
+                        genericsPrintf( C_SUPPORT2 "%s" C_RESET "::" C_CONTEXT "%d" EOL, d ? d : SymbolFunction( _r.s, report[n].n->functionindex ), report[n].n->line );
                     }
                     else
                     {
-                        fprintf( stdout, C_SUPPORT2 "%s" C_RESET EOL, d ? d : SymbolFunction( _r.s, report[n].n->functionindex ) );
+                        genericsPrintf( C_SUPPORT2 "%s" C_RESET EOL, d ? d : SymbolFunction( _r.s, report[n].n->functionindex ) );
                     }
 
                     printed++;
@@ -656,9 +657,9 @@ static void _outputTop( uint32_t total, uint32_t reportLines, struct reportLine 
         }
     }
 
-    fprintf( stdout, C_RESET "-----------------" EOL );
+    genericsPrintf( C_RESET "-----------------" EOL );
 
-    fprintf( stdout, C_DATA "%3d.%02d%% " C_SUPPORT " %7" PRIu64 " " C_RESET "of "C_DATA" %" PRIu64 " "C_RESET" Samples" EOL, totPercent / 100, totPercent % 100, dispSamples, samples );
+    genericsPrintf( C_DATA "%3d.%02d%% " C_SUPPORT " %7" PRIu64 " " C_RESET "of "C_DATA" %" PRIu64 " "C_RESET" Samples" EOL, totPercent / 100, totPercent % 100, dispSamples, samples );
 
     if ( p )
     {
@@ -677,11 +678,11 @@ static void _outputTop( uint32_t total, uint32_t reportLines, struct reportLine 
         /* Tidy up screen output */
         while ( printed++ <= options.cutscreen )
         {
-            fprintf( stdout, EOL );
+            genericsPrintf( EOL );
         }
 
-        fprintf( stdout, EOL " Exception         |   Count  |  MaxD | TotalTicks  |  AveTicks  |  minTicks  |  maxTicks  " EOL );
-        fprintf( stdout, /**/"-------------------+----------+-------+-------------+------------+------------+------------" EOL );
+        genericsPrintf( EOL " Exception         |   Count  |  MaxD | TotalTicks  |  AveTicks  |  minTicks  |  maxTicks  " EOL );
+        genericsPrintf( /**/"-------------------+----------+-------+-------------+------------+------------+------------" EOL );
 
         for ( uint32_t e = 0; e < MAX_EXCEPTIONS; e++ )
         {
@@ -699,25 +700,25 @@ static void _outputTop( uint32_t total, uint32_t reportLines, struct reportLine 
                     snprintf( exceptionName, sizeof( exceptionName ), "(IRQ %d)", e - 16 );
                 }
 
-                fprintf( stdout, C_DATA "%3" PRId32 " %-14s" C_RESET " | " C_DATA "%8" PRIu64 C_RESET " |" C_DATA " %5"
+                genericsPrintf( C_DATA "%3" PRId32 " %-14s" C_RESET " | " C_DATA "%8" PRIu64 C_RESET " |" C_DATA " %5"
                          PRIu32 C_RESET " | "C_DATA " %9" PRIu64 C_RESET "  |  " C_DATA "%9" PRIu64 C_RESET " | " C_DATA "%9" PRIu64 C_RESET "  | " C_DATA" %9" PRIu64 C_RESET EOL,
                          e, exceptionName, _r.er[e].visits, _r.er[e].maxDepth, _r.er[e].totalTime, _r.er[e].totalTime / _r.er[e].visits, _r.er[e].minTime, _r.er[e].maxTime );
             }
         }
     }
 
-    fprintf( stdout, EOL C_RESET "[%s%s%s%s" C_RESET "] ",
+    genericsPrintf( EOL C_RESET "[%s%s%s%s" C_RESET "] ",
              ( _r.ITMoverflows != ITMDecoderGetStats( &_r.i )->overflow ) ? C_OVF_IND "V" : C_RESET "-",
              ( _r.SWPkt != ITMDecoderGetStats( &_r.i )->SWPkt ) ? C_SOFT_IND "S" : C_RESET "-",
              ( _r.TSPkt != ITMDecoderGetStats( &_r.i )->TSPkt ) ? C_TSTAMP_IND "T" : C_RESET "-",
              ( _r.HWPkt != ITMDecoderGetStats( &_r.i )->HWPkt ) ? C_HW_IND "H" : C_RESET "-" );
 
     if ( _r.lastReportTicks )
-        fprintf( stdout, "Interval = " C_DATA "%" PRIu64 "mS " C_RESET "/ "C_DATA "%" PRIu64 C_RESET " (~" C_DATA "%" PRIu64 C_RESET " Ticks/mS)" EOL,
+        genericsPrintf( "Interval = " C_DATA "%" PRIu64 "mS " C_RESET "/ "C_DATA "%" PRIu64 C_RESET " (~" C_DATA "%" PRIu64 C_RESET " Ticks/mS)" EOL,
                  lastTime - _r.lastReportmS, _r.timeStamp - _r.lastReportTicks, ( _r.timeStamp - _r.lastReportTicks ) / ( lastTime - _r.lastReportmS ) );
     else
     {
-        fprintf( stdout, C_RESET "Interval = " C_DATA "%" PRIu64 C_RESET "mS" EOL, lastTime - _r.lastReportmS );
+        genericsPrintf( C_RESET "Interval = " C_DATA "%" PRIu64 C_RESET "mS" EOL, lastTime - _r.lastReportmS );
     }
 
     genericsReport( V_INFO, "         Ovf=%3d  ITMSync=%3d TPIUSync=%3d ITMErrors=%3d" EOL,
@@ -910,35 +911,59 @@ void _printHelp( char *progName )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, progName );
-    genericsPrintf( "       -c: <num> Cut screen output after number of lines" EOL );
-    genericsPrintf( "       -d: <DeleteMaterial> to take off front of filenames" EOL );
-    genericsPrintf( "       -D: Switch off C++ symbol demangling" EOL );
-    genericsPrintf( "       -e: <ElfFile> to use for symbols" EOL );
-    genericsPrintf( "       -E: Include exceptions in output report" EOL );
-    genericsPrintf( "       -f: <filename> Take input from specified file" EOL );
-    genericsPrintf( "       -g: <LogFile> append historic records to specified file" EOL );
-    genericsPrintf( "       -h: This help" EOL );
-    genericsPrintf( "       -I: <interval> Display interval in milliseconds (defaults to %d mS)" EOL, TOP_UPDATE_INTERVAL );
-    genericsPrintf( "       -j: <filename> Output to file in JSON format (or screen if <filename> is '-')" EOL );
-    genericsPrintf( "       -l: Aggregate per line rather than per function" EOL );
-    genericsPrintf( "       -n: Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
-    genericsPrintf( "       -o: <filename> to be used for output live file" EOL );
-    genericsPrintf( "       -O: <options> Options to pass directly to objdump" EOL );
-    genericsPrintf( "       -r: <routines> to record in live file (default %d routines)" EOL, options.maxRoutines );
-    genericsPrintf( "       -R: Report filenames as part of function discriminator" EOL );
-    genericsPrintf( "       -s: <Server>:<Port> to use" EOL );
-    genericsPrintf( "       -t: <channel> Use TPIU decoder on specified channel" EOL );
-    genericsPrintf( "       -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -c, --cut-after:    <num> Cut screen output after number of lines" EOL );
+    genericsPrintf( "    -D, --no-demangle:  Switch off C++ symbol demangling" EOL );
+    genericsPrintf( "    -d, --del-prefix:   <DeleteMaterial> to take off front of filenames" EOL );
+    genericsPrintf( "    -e, --elf-file:     <ElfFile> to use for symbols" EOL );
+    genericsPrintf( "    -E, --exceptions:   Include exceptions in output report" EOL );
+    genericsPrintf( "    -f, --input-file:   <filename> Take input from specified file" EOL );
+    genericsPrintf( "    -g, --record-file:  <LogFile> append historic records to specified file" EOL );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -I, --interval:     <interval> Display interval in milliseconds (defaults to %d ms)" EOL, TOP_UPDATE_INTERVAL );
+    genericsPrintf( "    -j, --json-file:    <filename> Output to file in JSON format (or screen if <filename> is '-')" EOL );
+    genericsPrintf( "    -l, --agg-lines:    Aggregate per line rather than per function" EOL );
+    genericsPrintf( "    -n, --itm-sync:     Enforce sync requirement for ITM (i.e. ITM needs to issue syncs)" EOL );
+    genericsPrintf( "    -o, --output-file:  <filename> to be used for output live file" EOL );
+    genericsPrintf( "    -O, --objdump-opts: <options> Options to pass directly to objdump" EOL );
+    genericsPrintf( "    -r, --routines:     <routines> to record in live file (default %d routines)" EOL, options.maxRoutines );
+    genericsPrintf( "    -R, --report-files: Report filenames as part of function discriminator" EOL );
+    genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
+    genericsPrintf( "    -t, --tpiu:         <channel> Use TPIU decoder on specified channel" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
     genericsPrintf( EOL "Environment Variables;" EOL );
     genericsPrintf( "  OBJDUMP: to use non-standard obbdump binary" EOL );
 }
 // ====================================================================================================
+struct option longOptions[] =
+{
+    {"cut-after", required_argument, NULL, 'c'},
+    {"no-demangle", required_argument, NULL, 'D'},
+    {"del-prefix", required_argument, NULL, 'd'},
+    {"elf-file", required_argument, NULL, 'e'},
+    {"exceptions", no_argument, NULL, 'E'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"record-file", required_argument, NULL, 'g'},
+    {"help", no_argument, NULL, 'h'},
+    {"interval", required_argument, NULL, 'I'},
+    {"json-file", required_argument, NULL, 'j'},
+    {"agg-lines", no_argument, NULL, 'l'},
+    {"itm-sync", no_argument, NULL, 'n'},
+    {"output-file", required_argument, NULL, 'o'},
+    {"objdump-opts", required_argument, NULL, 'O'},
+    {"routines", required_argument, NULL, 'r'},
+    {"report-files", no_argument, NULL, 'R'},
+    {"server", required_argument, NULL, 's'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"verbose", required_argument, NULL, 'v'},
+    {NULL, no_argument, NULL, 0}
+};
+// ====================================================================================================
 int _processOptions( int argc, char *argv[] )
 
 {
-    int c;
+    int c, optionIndex = 0;
 
-    while ( ( c = getopt ( argc, argv, "c:d:DEe:f:g:hI:j:lm:nO:o:r:Rs:t:v:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "c:d:DEe:f:g:hI:j:lm:nO:o:r:Rs:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -1239,7 +1264,7 @@ int main( int argc, char *argv[] )
 
         if ( ( !options.json ) || ( options.json[0] != '-' ) )
         {
-            fprintf( stdout, CLEAR_SCREEN "Connected..." EOL );
+            genericsPrintf( CLEAR_SCREEN "Connected..." EOL );
         }
 
         /* ...just in case we have any readings from a previous incantation */

--- a/Src/orbtrace.c
+++ b/Src/orbtrace.c
@@ -128,7 +128,7 @@ static void _intHandler( int sig )
     exit( 0 );
 }
 // ====================================================================================================
-static void _printHelp( char *progName )
+static void _printHelp( const char *const progName )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, progName );

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -358,9 +358,15 @@ void _printHelp( char *progName )
     genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
     genericsPrintf( "    -t, --tpiu:         <Channel , ...> Use TPIU channels (and strip TIPU framing from output flows)" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -V, --version:      Print version and exit" EOL );
 }
 
 // ====================================================================================================
+void _printVersion( void )
+
+{
+    genericsPrintf( "oruculum version " GIT_DESCRIBE EOL );
+}
 // ====================================================================================================
 struct option longOptions[] =
 {
@@ -375,6 +381,7 @@ struct option longOptions[] =
     {"server", required_argument, NULL, 's'},
     {"tpiu", required_argument, NULL, 't'},
     {"verbose", required_argument, NULL, 'v'},
+    {"version", no_argument, NULL, 'V'},
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
@@ -384,7 +391,7 @@ int _processOptions( int argc, char *argv[], struct RunTime *r )
     int c, optionIndex = 0;
 #define DELIMITER ','
 
-    while ( ( c = getopt_long ( argc, argv, "a:ef:hl:m:no:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "a:ef:hVl:m:no:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------
@@ -407,6 +414,11 @@ int _processOptions( int argc, char *argv[], struct RunTime *r )
             // ------------------------------------
             case 'h':
                 _printHelp( argv[0] );
+                return false;
+
+            // ------------------------------------
+            case 'V':
+                _printVersion();
                 return false;
 
             // ------------------------------------

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -343,7 +343,7 @@ static void _doExit( void )
     }
 }
 // ====================================================================================================
-void _printHelp( char *progName )
+void _printHelp( const char *const progName )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, progName );

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -356,7 +356,7 @@ void _printHelp( const char *const progName )
     genericsPrintf( "    -o, --output-file:  <filename> to be used for dump file" EOL );
     genericsPrintf( "    -p, --serial-port:  <serialPort> to use" EOL );
     genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
-    genericsPrintf( "    -t, --tpiu:         <Channel , ...> Use TPIU channels (and strip TIPU framing from output flows)" EOL );
+    genericsPrintf( "    -t, --tpiu:         <Channel , ...> Use TPIU channels (and strip TPIU framing from output flows)" EOL );
     genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
     genericsPrintf( "    -V, --version:      Print version and exit" EOL );
 }

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -385,7 +385,7 @@ struct option longOptions[] =
     {NULL, no_argument, NULL, 0}
 };
 // ====================================================================================================
-int _processOptions( int argc, char *argv[], struct RunTime *r )
+bool _processOptions( int argc, char *argv[], struct RunTime *r )
 
 {
     int c, optionIndex = 0;

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -24,6 +24,7 @@
 #include <strings.h>
 #include <string.h>
 #include <pthread.h>
+#include <getopt.h>
 #if defined OSX
     #include <sys/ioctl.h>
     #include <libusb.h>
@@ -346,27 +347,44 @@ void _printHelp( char *progName )
 
 {
     genericsPrintf( "Usage: %s [options]" EOL, progName );
-    genericsPrintf( "       -a: <serialSpeed> to use" EOL );
-    genericsPrintf( "       -e: When reading from file, terminate at end of file" EOL );
-    genericsPrintf( "       -f: <filename> Take input from specified file" EOL );
-    genericsPrintf( "       -h: This help" EOL );
-    genericsPrintf( "       -l: <port> Listen port for the incoming connections (defaults to %d)" EOL, NWCLIENT_SERVER_PORT );
-    genericsPrintf( "       -m: <interval> Output monitor information about the link at <interval>ms" EOL );
-    genericsPrintf( "       -o: <filename> to be used for dump file" EOL );
-    genericsPrintf( "       -p: <serialPort> to use" EOL );
-    genericsPrintf( "       -s: <Server>:<Port> to use" EOL );
-    genericsPrintf( "       -t: <Channel , ...> Use TPIU channels (and strip TIPU framing from output flows)" EOL );
-    genericsPrintf( "       -v: <level> Verbose mode 0(errors)..3(debug)" EOL );
+    genericsPrintf( "    -a, --serial-speed: <serialSpeed> to use" EOL );
+    genericsPrintf( "    -e, --eof:          When reading from file, terminate at end of file" EOL );
+    genericsPrintf( "    -f, --input-file:   <filename> Take input from specified file" EOL );
+    genericsPrintf( "    -h, --help:         This help" EOL );
+    genericsPrintf( "    -l, --listen-port:  <port> Listen port for the incoming connections (defaults to %d)" EOL, NWCLIENT_SERVER_PORT );
+    genericsPrintf( "    -m, --monitor:      <interval> Output monitor information about the link at <interval>ms" EOL );
+    genericsPrintf( "    -o, --output-file:  <filename> to be used for dump file" EOL );
+    genericsPrintf( "    -p, --serial-port:  <serialPort> to use" EOL );
+    genericsPrintf( "    -s, --server:       <Server>:<Port> to use" EOL );
+    genericsPrintf( "    -t, --tpiu:         <Channel , ...> Use TPIU channels (and strip TIPU framing from output flows)" EOL );
+    genericsPrintf( "    -v, --verbose:      <level> Verbose mode 0(errors)..3(debug)" EOL );
 }
 
+// ====================================================================================================
+// ====================================================================================================
+struct option longOptions[] =
+{
+    {"serial-speed", required_argument, NULL, 'a'},
+    {"eof", no_argument, NULL, 'e'},
+    {"input-file", required_argument, NULL, 'f'},
+    {"help", no_argument, NULL, 'h'},
+    {"listen-port", required_argument, NULL, 'l'},
+    {"monitor", required_argument, NULL, 'm'},
+    {"output-file", required_argument, NULL, 'o'},
+    {"serial-port", required_argument, NULL, 'p'},
+    {"server", required_argument, NULL, 's'},
+    {"tpiu", required_argument, NULL, 't'},
+    {"verbose", required_argument, NULL, 'v'},
+    {NULL, no_argument, NULL, 0}
+};
 // ====================================================================================================
 int _processOptions( int argc, char *argv[], struct RunTime *r )
 
 {
-    int c;
+    int c, optionIndex = 0;
 #define DELIMITER ','
 
-    while ( ( c = getopt ( argc, argv, "a:ef:hl:m:no:p:s:t:v:" ) ) != -1 )
+    while ( ( c = getopt_long ( argc, argv, "a:ef:hl:m:no:p:s:t:v:", longOptions, &optionIndex ) ) != -1 )
         switch ( c )
         {
             // ------------------------------------


### PR DESCRIPTION
This PR implements longopts for all programs other than orbtrace, and provides a version option (-V/--version) for all programs

This also introduces a means to prevent everything being rebuilt every `make` invocation by being able to choose to rebuild the version header only when the version information would change. A PR containing that will follow as discussed on Discord.