### PR TITLE
Add ncurses to linux build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Dependencies
 ------------
 * libusb-1.0
 * libczmq-dev
+* ncurses
 
 Note that `objdump`  version at least 2.33.1 is also required. By default the suite will run `arm-none-eabi-objdump` but another binary or pathname can be
 subsituted via the OBJDUMP environment variable.


### PR DESCRIPTION
Hi there, I packaged this for NixOS, and it required ncurses to build successfully: https://github.com/NixOS/nixpkgs/pull/186039

ncurses is used in `sio.c`: https://github.com/orbcode/orbuculum/blob/ccb0790fc159a15989076a03fe12bc4c699749ff/Src/sio.c#L15

I figured adding this to the README with the others will help other people with packing/install :)

