### PR TITLE
Fix build&doc on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Building on OSX
 Recipie instructions courtesy of FrankTheTank;
 
 * `brew install libusb`
+* `brew install zmq`
 
 and finally;
 
@@ -325,15 +326,15 @@ For `orbuculum`, the specific command line options of note are;
  `-a, --serial-speed: [serialSpeed]`: Use serial port and set device speed.
 
  `-E, --eof`: When reading from file, ignore eof.
- 
+
  `-f, --input-file [filename]`: Take input from file rather than device.
- 
+
  `-h, --help`: Brief help.
 
  `-m, --monitor`: Monitor interval (in mS) for reporting on state of the link. If baudrate is specified (using `-a`) and is greater than 100bps then the percentage link occupancy is also reported.
 
   `-o, --output-file [filename]`: Record trace data locally. This is unfettered data directly from the source device, can be useful for replay purposes or other tool testing.
-  
+
   `-p, --serial-port [serialPort]`: to use. If not specified then the program defaults to Blackmagic probe.
 
   `-s, --server [address]:[port]`: Set address for explicit TCP Source connection, (default none:2332).
@@ -615,33 +616,33 @@ configured to stream parallel trace info (clue; the `startETM` option).
 The command line options of note are;
 
  `-a, --alt-addr-enc`: Don't use alternate address encoding. Select this if decodes don't seem to arrive correctly. You can discover if you need this option by using the `describeETM` command inside the debugger.
- 
+
  `-b, --buffer-len [Length]`: Set length of post-mortem buffer, in KBytes (Default 32 KBytes)
- 
+
  `-c, --editor-cmd [command]`: Set command line for external editor (0.000000 = filename, % = line). A few examples are;
- 
+
      * emacs; `-c emacs "+%l %f"`
      * codium/VSCode; `-c codium  -g "%f:%l"`
      * eclipse; `-c eclipse "%f:%l"`
-     
+
  `-D, --no-demangle`: Switch off C++ symbol demangling
- 
+
  `-d, --del-prefix [String]`: Material to delete off front of filenames
- 
+
  `-e, --elf-file [ElfFile]`: to use for symbols and source
- 
+
  `-E, --eof`: When reading from file, terminate at end of file rather than waiting for further input
- 
+
  `-f, --input-file [filename]`: Take input from specified file rather than live from a probe (useful for ETB decode)
 
  `-h, --help`: Provide brief help
- 
+
  `-p, --trace-proto [protocol]`: to use, where protocols are MTB or ETM35 (default). Note that MTB only makes sense from a file.
- 
+
  `-s, --server [Server:Port]`: to use
- 
+
  `-t, --tpiu [channel]`: Use TPIU to strip TPIU on specfied channel (normally best to let `orbuculum` handle this
- 
+
 
 Once it's running you will receive an indication at the lower right of the screen that it's capturing data. Hitting `H` will hold the capture and it will decode whatever is currently in the buffer. More usefully, if the capture stream is lost (e.g. because of debugger entry) then it will auto-hold and decode the buffer, showing you the last instructions executed. You can use the arrow keys to move around this buffer and dive into individual source files. Hit the `?` key for a quick overview of available commands.
 

--- a/Src/nwclient.c
+++ b/Src/nwclient.c
@@ -17,7 +17,9 @@
     #include <netinet/in.h>
     #include <netdb.h>
     #include <arpa/inet.h>
+#ifndef OSX
     #include <linux/tcp.h>
+#endif
     #include <string.h>
 #endif
 #include <assert.h>


### PR DESCRIPTION
linux/tcp.h doesn't exist on OSX.
Add ZeroMQ headers.