### PR TITLE
Fix redefinition of MSG_NOSIGNAL on Mac

### DIFF
--- a/Src/nwclient.c
+++ b/Src/nwclient.c
@@ -36,7 +36,9 @@
 #endif
 
 #ifdef OSX
-    #define MSG_NOSIGNAL 0
+    #ifndef MSG_NOSIGNAL
+        #define MSG_NOSIGNAL 0
+    #endif
 #endif
 
 /* Shared ring buffer for data */


### PR DESCRIPTION
MSG_NOSIGNAL used to be missing on Mac but was defined starting in a fairly recent macOS (Monterey maybe?)