### PR TITLE
Use forked libusb repository for Windows build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,20 +17,40 @@ jobs:
           msystem: MINGW64
           install: >-
             base-devel
-            mingw-w64-x86_64-libusb
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-zeromq
             mingw-w64-x86_64-SDL2
             git
             zip
             mingw-w64-x86_64-meson
+            mingw-w64-x86_64-autotools
       - uses: actions/checkout@v3
-      - run: meson setup ./build --prefix A:/
+        with:
+          path: ./orbuculum
+      - uses: actions/checkout@v3
+        with:
+          path: ./libusb/src
+          repository: Novakov/libusb
+          ref: d67cf6868b91c5972aa4225caf9b924f25a9bda6
+
+      - run: ./bootstrap.sh
+        working-directory: ./libusb/src
+      - run: mkdir ./libusb/build
+      - run: ../src/configure --prefix=`realpath ../install`
+        working-directory: ./libusb/build
+      - run: make -j4 install
+        working-directory: ./libusb/build
+
+      - run: "export PKG_CONFIG_PATH=`realpath ../libusb/install/lib/pkgconfig` && meson setup ./build --prefix A:/"
+        working-directory: ./orbuculum
       - run: ninja -C ./build
+        working-directory: ./orbuculum
       - run: meson install -C ./build --destdir ./install --strip
+        working-directory: ./orbuculum
+      - run: cp ./libusb/install/bin/libusb-1.0.dll ./orbuculum/build/install/bin
       - uses: actions/upload-artifact@v3
         with:
           name: orbuculum-win64
-          path: build/install/**/*.*
+          path: ./orbuculum/build/install/**/*.*
           if-no-files-found: error
 

--- a/Inc/orbtraceIf.h
+++ b/Inc/orbtraceIf.h
@@ -20,7 +20,7 @@
     #if defined LINUX
         #include <libusb-1.0/libusb.h>
     #elif defined WIN32
-        #include <libusb-1.0/libusb.h>
+        #include <libusb.h>
     #else
         #error "Unknown OS"
     #endif

--- a/README.md
+++ b/README.md
@@ -1019,3 +1019,17 @@ and then;
 
 However, that's probably over-complicated now...just use the orbuculum -s option to hook to any source that
 is pumping out clean SWO data. This information is just left here to show the flexibilities you have got available.
+
+
+Windows: concurrent debug and Orbuculum usage with Orbtrace
+===========================================================
+
+Due to issue in Libusb (https://github.com/libusb/libusb/issues/1177 and https://github.com/libusb/libusb/pull/1181) running orbuculum or OpenOCD (or any other tool using libusb to access CMSIS-DAP) will claim exclusively entrie Orbtrace device preventing other application from running (e.g. while orbuculum is running OpenOCD will fail to find debug probe). Some debug software might be able to fallback to HID interface of CMSIS-DAP, however this will be much slower than "proper" USB Bulk interface.
+
+In order to ease pain of this issue, Orbuculum distribution for Windows built on Github (https://github.com/orbcode/orbuculum/actions/workflows/build-windows.yml?query=branch%3Amain) is built with patched libusb. While this alone might not be enough for debug applications to work properly (with USB build interface) at least Orbuculum itselt will not act hostile to other applications. In order to get debug application working with patched libusb there are two options:
+* Rebuild application with patched libusb (https://github.com/Novakov/libusb/tree/winusb-lazy-create-file) - harder to do but have the greatest chance of success
+* Replace `libusb-1.0.dll` bundled with debug application in use with `libusb-1.0.dll` from Orbuculum distribution - easier to do but might not work with all applications.
+
+The later approach (file replacement) works fine for PyOCD (replace `libusb-1.0.dll` file in `<venv>/Lib/site-packages/libusb_package`) and fails to work with xPack OpenOCD (due to the way `libftdi.dll` is built).
+
+Please report both success (this will increase chances of merging patch to upstream libusb) and failures (so we will be able to identify and fix issues introduced by patch) with this approach.

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -43,7 +43,7 @@
             #include <termios.h>
         #endif
     #elif defined WIN32
-        #include <libusb-1.0/libusb.h>
+        #include <libusb.h>
     #else
         #error "Unknown OS"
     #endif

--- a/win32/install_dlls.sh
+++ b/win32/install_dlls.sh
@@ -2,7 +2,6 @@
 
 for f in $MESON_INSTALL_DESTDIR_PREFIX/bin/*.exe
 do
-    echo $f
     ldd $f | grep -vi System32 | grep -vi liborb | gawk '{ print $3 }' | xargs -rt cp -t $MESON_INSTALL_DESTDIR_PREFIX/bin
     echo "---"
 done


### PR DESCRIPTION
This pull request modified Windows Github build to use forked libusb repository with fixed exclusive access issue (https://github.com/libusb/libusb/issues/1177 and https://github.com/libusb/libusb/pull/1181) - see more in README. 

My hope is to ease working with orbuculum and gather some feedback regarding libusb fix. Best case scenario it would generate enough feedback to convince maintainers to merge it.

Build definition is terrible but meson is not so collaborative in this case and fighting with it to overcome (potentially temporary) workaround is not worth it