### PR TITLE
msgDecoder: fix data watchpoint read handling

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,6 +7,7 @@ Tom Keddie             github@bronwenandtom.com
 Francois Killeen       killeenfrancois@gmail.com
 Andrew Kohlsmith
 Devan Lai              devan.lai@gmail.com                     *3
+Florian Larysch        fl@n621.de
 Maciej Nowak           maciejt.nowak@gmail.com
 Rachel Mant            git@dragonmux.network
 Dave Marples           dave@marples.net                        *4

--- a/Src/msgDecoder.c
+++ b/Src/msgDecoder.c
@@ -136,7 +136,7 @@ static bool _handleHW( struct ITMPacket *packet, struct msg *decoded )
 
         // --------------
         default:
-            if ( ( packet->srcAddr & 0x19 ) == 0x11 )
+            if ( ( ( packet->srcAddr & 0x19 ) == 0x10 ) || ( ( packet->srcAddr & 0x19 ) == 0x11 ) )
             {
                 wasDecoded = _handleDataRWWP( packet, ( struct watchMsg * )decoded );
             }


### PR DESCRIPTION
The least significant bit of the source address/discriminator in data trace packets encodes whether it is a read or a write and _handleDataRWWP properly handles this.

However, _handleHW will currently only call _handleDataRWWP when the least significant byte is set (corresponding to a write), causing trace packets corresponding to read operations to be discarded.

Extend the check to call _handleDataRWWP in both cases.

_NB_: This is just based on me reading the code in parallel to the ARM docs trying to understand how everything works. I have neither encountered this problem in reality nor tried to reproduce it yet, so I could just be misunderstanding things. However, it seems pretty straightforward, so I'm sending this PR "blind".