### PR TITLE
Allow orbuculum to be used as a meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,16 +17,16 @@ if host_machine.system() == 'windows'
         winsock2
     ]
 elif host_machine.system() == 'darwin'
-    add_global_arguments('-DOSX', language: 'c')
+    add_project_arguments('-DOSX', language: 'c')
 else
-    add_global_arguments('-DLINUX', language: 'c')
-    add_global_arguments('-D_GNU_SOURCE', language: 'c')
+    add_project_arguments('-DLINUX', language: 'c')
+    add_project_arguments('-D_GNU_SOURCE', language: 'c')
     install_data('Support/60-orbcode.rules', install_dir : '/etc/udev/rules.d')
     install_data('Support/gdbtrace.init', install_dir : 'share/orbcode')
 endif
 
-add_global_arguments('-DSCREEN_HANDLING', language: 'c')
-add_global_arguments(['-include', 'uicolours_default.h'], language: 'c')
+add_project_arguments('-DSCREEN_HANDLING', language: 'c')
+add_project_arguments(['-include', 'uicolours_default.h'], language: 'c')
 
 if host_machine.system() == 'windows'
     stream_src = [


### PR DESCRIPTION
Hi,

I'm building orbuculum as a meson subproject, which currently fails due to the use of `add_global_arguments`:

```
subprojects/orbuculum/meson.build:20:4: ERROR: Function 'add_global_arguments' cannot be used in subprojects because there is no way to make that reliable.
Please only call this if is_subproject() returns false. Alternatively, define a variable that
contains your language-specific arguments and add it to the appropriate *_args kwarg in each target.
```

A simple fix is to replace it with `add_project_arguments` instead, which does the same thing, but doesn't leak into the other subprojects.