### PR TITLE
localtime too new & libusb deprecations

### DIFF
--- a/Src/orbcat.c
+++ b/Src/orbcat.c
@@ -146,7 +146,7 @@ static void _outputTimestamp( void )
         case TSAbsolute: // -------------------------------------------------------------------
             res = _timestamp();
             td = ( time_t )res / ONE_SEC_IN_USEC;
-            localtime_r( &td, &tm );
+            tm = *localtime( &td );
             strftime( opConstruct, MAX_STRING_LENGTH, ABS_FORMAT_TM, &tm );
             fprintf( stdout, ABS_FORMAT, opConstruct, ( res / ( ONE_SEC_IN_USEC / 1000 ) ) % 1000 );
             break;

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ else
 endif
 
 add_project_arguments('-DSCREEN_HANDLING', language: 'c')
+add_project_arguments('-Wno-error=deprecated-declarations', language: 'c')
 add_project_arguments(['-include', 'uicolours_default.h'], language: 'c')
 
 if host_machine.system() == 'windows'


### PR DESCRIPTION
1) Libusb at some point in time marked libusb_init as deprecated (they later undo the deprecation) which is reported as warning.
2) `localtime_r` is available from C23 which a bit too new.