### PR TITLE
Fix overflow in reporting data transfer rate in orbuculum

### DIFF
--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -103,7 +103,7 @@ struct RunTime
     struct TPIUDecoder t;                                /* TPIU decoder instance, in case we need it */
     struct OrbtraceIf  *o;                               /* For accessing ORBTrace devices + BMPs */
 
-    long int  intervalBytes;                             /* Number of bytes transferred in current interval */
+    uint64_t  intervalBytes;                             /* Number of bytes transferred in current interval */
 
     pthread_t intervalThread;                            /* Thread reporting on intervals */
     pthread_t processThread;                             /* Thread for processing prior to distributing to clients */


### PR DESCRIPTION
I have noticed with default 1000 ms interval my bitrate calculations are off, 8Mbit vs expected hundreds. This what fixed my calculations