### PR TITLE
another overflow, now in percent calculations.

### DIFF
--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -93,7 +93,7 @@ struct Options
 struct handlers
 {
     int channel;                                         /* Channel number for this handler */
-    long int intervalBytes;                              /* Number of depacketised bytes output on this channel */
+    uint64_t intervalBytes;                              /* Number of depacketised bytes output on this channel */
     struct dataBlock *strippedBlock;                     /* Processed buffers for output to clients */
     struct nwclientsHandle *n;                           /* Link to the network client subsystem */
 };


### PR DESCRIPTION
This fixes those negative percentages then stripping tpiu, after making counter unsigned they became visible as huge numbers
![image](https://github.com/orbcode/orbuculum/assets/1855089/1f6bcd7f-ae5e-4fe1-8c3c-5f550e630f37)
