### PR TITLE
add O_BINFARY only for itmfifos and orbuculum saving and reading from…

### DIFF
--- a/Src/itmfifos.c
+++ b/Src/itmfifos.c
@@ -120,11 +120,11 @@ static void *_runFifo( void *arg )
         /* We use RDWR to allow the open to proceed without a remote end */
         if ( !params->permafile )
         {
-            opfile = open( c->fifoName, O_RDWR | O_NONBLOCK );
+            opfile = open( c->fifoName, O_RDWR | O_BINARY | O_NONBLOCK );
         }
         else
         {
-            opfile = open( c->fifoName, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH );
+            opfile = open( c->fifoName, O_WRONLY | O_CREAT | O_BINARY  | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH );
         }
 
         do
@@ -212,11 +212,11 @@ static void *_runHWFifo( void *arg )
         if ( !params->permafile )
         {
             /* We use RDWR to allow the open to proceed without a remote end */
-            opfile = open( c->fifoName, O_RDWR | O_NONBLOCK );
+            opfile = open( c->fifoName, O_RDWR | O_BINARY | O_NONBLOCK );
         }
         else
         {
-            opfile = open( c->fifoName, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH );
+            opfile = open( c->fifoName, O_WRONLY | O_CREAT | O_BINARY  | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH );
         }
 
         do


### PR DESCRIPTION
I did some tests in windows, added those missing O_BINARY flags, but id did not fix my file to file test
but this test was still failing.
orbuculum --input-file r:/output.bin --eof -v 2 -o r:/copy.bin

Not sure if was intended but I have noticed that we can miss some signals, I fixed that and now it is lightning speed and copy file is the same as input file.