### PR TITLE
Outputting \r\n if not necessary on Windows

### DIFF
--- a/Inc/generics.h
+++ b/Inc/generics.h
@@ -14,11 +14,7 @@
 #include <stdint.h>
 #include <errno.h>
 
-#if defined LINUX
-    #define EOL "\n"
-#else
-    #define EOL "\r\n"
-#endif
+#define EOL "\n"
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Windows, by default, sets stdout to _O_TEXT mode which automatically handles transformation of \n into \r\n (and vice versa for stdin, source https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170#remarks).

Define EOL as \n as thats ok for both *nix and Windows. Additionally this solve issue with double new lines when redirecting orbcat output to file on Windows.