### PR TITLE
Fix STM32 GPIO configuration for Trace pins

### DIFF
--- a/Support/gdbtrace.init
+++ b/Support/gdbtrace.init
@@ -89,8 +89,9 @@ set $TPIUBASE=0xE0040000
 set $ETMBASE=0xE0041000
 
 define _setAddressesSTM32
-
-# Locations in the memory map for interesting things on STM32
+  # Locations in the memory map for interesting things on STM32
+  set $RCCBASE = 0x40023800
+  set $GPIOBASE = 0x40020000
 end
 
 define _setAddressesIMXRT
@@ -734,20 +735,11 @@ define enableSTM32SWO
   end
 
   set $CPU=$CPU_STM32
-   _setAddressesSTM32
+  _setAddressesSTM32
+
   if (($tgt==4) || ($tgt==7))
-    # STM32F4/7 variant.
-    # Enable AHB1ENR
-    set *0x40023830 |= 0x02
-    # Set MODER for PB3
-    set *0x40020400 &= ~(0x000000C0)
-    set *0x40020400 |= 0x00000080
-    # Set max (100MHz) speed in OSPEEDR
-    set *0x40020408 |= 0x000000C0
-    # No pull up or down in PUPDR
-    set *0x4002040C &= ~(0x000000C0)
-    # Set AF0 (==TRACESWO) in AFRL
-    set *0x40020420 &= ~(0x0000F000)
+    # STM32F4/7 variant: SWO on PB3.
+    enableSTM32Pin 1 3 3
   else
     # STM32F1 variant.
     # RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
@@ -838,10 +830,55 @@ define _doTRACE
 
   set *($TPIUBASE+0x304) = 0x102
 end
+
+# ====================================================================
+define enableSTM32Pin
+  #set language c
+  _setAddressesSTM32
+  set $_GPIOPORT = $GPIOBASE + 0x400 * $arg0
+
+  # Enable GPIO port in RCC
+  set *($RCCBASE + 0x30) |= (0x1<<$arg0)
+
+  # MODER: Alternate Function
+  set *($_GPIOPORT+0x00) &= ~(0x3<<2*$arg1)
+  set *($_GPIOPORT+0x00) |=   0x2<<2*$arg1
+
+  # OTYPER: Push-Pull
+  set *($_GPIOPORT+0x04) &= ~(0x1<<$arg1)
+
+  # OSPEEDR: Drive speed
+  set *($_GPIOPORT+0x08) &= ~(0x3<<2*$arg1)
+  set *($_GPIOPORT+0x08) |= $arg2<<2*$arg1
+
+  # PUPDR: No pullup or pulldown
+  set *($_GPIOPORT+0x0C) &= ~(0x3<<2*$arg1)
+
+  # AFRL: AF0
+  if ($arg1 < 8)
+    set *($_GPIOPORT+0x20) &= ~(0xF<<4*$arg1)
+  else
+    set *($_GPIOPORT+0x24) &= ~(0xF<<4*($arg1 - 8))
+  end
+
+  # LOCKR: lock pin until the next reset
+  set *($_GPIOPORT+0x1C) = 0x10000 | (0x1<<$arg1)
+  set *($_GPIOPORT+0x1C) = 0x00000 | (0x1<<$arg1)
+  set *($_GPIOPORT+0x1C) = 0x10000 | (0x1<<$arg1)
+  set $_null = *($_GPIOPORT+0x1C)
+
+  #set language auto
+end
+document enableSTM32Pin
+enableSTM32Pin <Port> <Pin> <Drive>: Enable TRACE function AF0 on a single STM32 pin
+  <Port>    : Number of the port (0=A, 1=B, 2=C, 3=D, 4=E, 5=F, 6=G, ...)
+  <Pin>     : Pin number in [0, 15]
+  <Drive>   : Drive strength (0=lowest, 3=highest)
+end
+
 # ====================================================================
 define enableSTM32TRACE
-
-#set language c
+  #set language c
 
   set $bits=4
   set $drive=1
@@ -868,47 +905,24 @@ define enableSTM32TRACE
 
   # Enable Trace TRCENA (DCB DEMCR) needed for clocks
   set *($CDBBASE+0xC)=(1<<24)
-  
-  # Enable AHB1ENR
-  set *0x40023830 |= 0x10
 
   # Enable compensation cell
   set *0x40023844 |= (1<<14)
   set *0x40013820 |=1
 
   # Setup PE2 & PE3
-  # Port Mode
-  set *0x40021000 &= ~(0x000000F0)
-  set *0x40021000 |= 0xA0
-
-  # Drive speed
-  set *0x40021008 &= ~0xf0
-  set *0x40021008 |= ($drive<<4)|($drive<<6)
-
-  # No Pull up or down
-  set *0x4002100C &= ~0xF0
-  # AF0
-  set *0x40021020 &= ~0xF0
+  enableSTM32Pin 4 2 $drive
+  enableSTM32Pin 4 3 $drive
 
   if ($bits>0)
      # Setup PE4
-     set *0x40021000 &= ~(0x00000300)
-     set *0x40021000 |= 0x200
-     set *0x40021008 &= ~0x300
-     set *0x40021008 |= ($drive<<8)
-     set *0x4002100C &= ~0x300
-     set *0x40021020 &= ~0x300
+     enableSTM32Pin 4 4 $drive
   end
 
   if ($bits>1)
      # Setup PE5 & PE6
-
-     set *0x40021000 &= ~(0x00003C00)
-     set *0x40021000 |= 0x2800
-     set *0x40021008 &= ~0x3C00
-     set *0x40021008 |= ($drive<<10)|($drive<<12)
-     set *0x4002100C &= ~0x3C00
-     set *0x40021020 &= ~0x3C00
+     enableSTM32Pin 4 5 $drive
+     enableSTM32Pin 4 6 $drive
   end
 
   # Set number of bits in DBGMCU_CR


### PR DESCRIPTION
My application reuses the trace pins for LEDs, thus the application configures the pins during runtime.
I first added locking to the pins, so that any writes from the application are ignored and then noticed that the masks were wrong.
I've now added a subfunction to configure one pin at a time to remove the manual mask computations.

In addition, I've mapped some of the trace data to other pins, so the `enableSTM32Pin` function lets you specify a port. (in my case, TRACED3 is mapped to PC12).