### PR TITLE
Added instruction on how to install on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Dependencies
 * libsdl
 * libelf-dev
 * libcapstone-dev
+* cmake
 
 Build
 -----
@@ -258,6 +259,12 @@ If you do want to build the system, then the command line to build the Orbuculum
 ```
 >meson setup build
 >ninja -C build
+```
+
+You can install the build files by using: 
+
+```
+>meson install -c build
 ```
 
 You may need to change the paths to your libusb files, depending on how well your build environment is set up. You might also want to change the install path, which defaults to putting everything under `/usr/local` by passing the appropriate path to meson with a command line such as `meson setup --prefix=/usr build`...we've had some feedback that Arch doesn't find libraries under `/usr/local/lib`, for example. It's also worth noting that Ubuntu comes with a pretty old version of meson so if you get errors you may need to install a more recent one via pip.


### PR DESCRIPTION
For some reason it seemed to require cmake on my machine, so I added that to the docs. 

Initially I could not figure how to actually make it install on Linux, I was not familiar with meson so I had to search for it, I thought this might be useful for others. 

Also, for some reason, it initially could not find the freshly built .so's on my system, so I had to run ldconfig. Not sure if that's something I did  or what. 

When I installed meson, my build OS. (Pop! OS 22.04) had a _really old version _ of meson that it installed from the apt repos. So I had to install it using pip. 