### PR TITLE
Add missing C++ include guards

### DIFF
--- a/Inc/loadelf.h
+++ b/Inc/loadelf.h
@@ -4,6 +4,10 @@
 #include <stdbool.h>
 #include <capstone/capstone.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef unsigned long int symbolMemaddr;
 typedef unsigned char *symbolMemptr;
 
@@ -128,4 +132,7 @@ bool symbolSetValid( struct symbol *p );
 
 // ====================================================================================================
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/Inc/loadelf.h
+++ b/Inc/loadelf.h
@@ -125,7 +125,7 @@ char *symbolDisassembleLine( struct symbol *p, enum instructionClass *ic, symbol
 void symbolDelete( struct symbol *p );
 
 /* Collect symbol set with specified components */
-struct symbol *symbolAquire( char *filename, bool loadlines, bool loadmem, bool loadsource );
+struct symbol *symbolAcquire( char *filename, bool loadlines, bool loadmem, bool loadsource );
 
 /* Check if current symbols are valid */
 bool symbolSetValid( struct symbol *p );

--- a/Inc/readsource.h
+++ b/Inc/readsource.h
@@ -1,11 +1,18 @@
 #ifndef _READSOURCE_H_
 #define _READSOURCE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // ====================================================================================================
 
 char *readsourcefile( char *path, size_t *l );
 
 // ====================================================================================================
 
+#ifdef __cplusplus
+}
+#endif
 #endif
 

--- a/Src/loadelf.c
+++ b/Src/loadelf.c
@@ -1102,7 +1102,7 @@ bool symbolSetValid( struct symbol *p )
 
 // ====================================================================================================
 
-struct symbol *symbolAquire( char *filename, bool loadlines, bool loadmem, bool loadsource )
+struct symbol *symbolAcquire( char *filename, bool loadlines, bool loadmem, bool loadsource )
 
 /* Collect symbol set with specified components */
 
@@ -1237,7 +1237,7 @@ void main( int argc, char *argv[] )
 
 {
     enum instructionClass ic;
-    struct symbol *p = symbolAquire( argv[1], true, true, true );
+    struct symbol *p = symbolAcquire( argv[1], true, true, true );
 
     if ( !p )
     {

--- a/Src/loadelf.c
+++ b/Src/loadelf.c
@@ -1128,7 +1128,7 @@ struct symbol *symbolAquire( char *filename, bool loadlines, bool loadmem, bool 
     }
 
     /* Load the functions and source code line mappings if requested */
-    if ( !_readLines( p ) )
+    if ( loadlines && !_readLines( p ) )
     {
         symbolDelete( p );
         return NULL;

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -998,7 +998,7 @@ static bool _dumpBuffer( struct RunTime *r )
     {
         symbolDelete( r->s );
 
-        if ( !( r->s = symbolAquire( r->options->elffile, true, true, true ) ) )
+        if ( !( r->s = symbolAcquire( r->options->elffile, true, true, true ) ) )
         {
             genericsReport( V_ERROR, "Elf file or symbols in it not found" EOL );
             return false;
@@ -1270,7 +1270,7 @@ int main( int argc, char *argv[] )
     }
 
     /* Check we've got _some_ symbols to start from */
-    _r.s = symbolAquire( _r.options->elffile, true, true, true );
+    _r.s = symbolAcquire( _r.options->elffile, true, true, true );
 
     if ( !_r.s )
     {


### PR DESCRIPTION
I'm trying to use loadelf from C++, thus the need for the extern "C".

Also fixes the spelling of symbolAcquire and respects the loadlines flag in that function.