### PR TITLE
build: install udev rules to relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,7 @@ You may need to change the paths to your libusb files, depending on how well you
 
 Permissions and Access
 ----------------------
-A udev rules files is included in ```Support/60-orbcode.rules```
-Install this to ```/etc/udev/rules.d``` to grant access to orbcode hardware, if required.
+A udev rules files is included in ```Support/60-orbcode.rules``` The default installations will have already installed this to either `/usr/local/lib/udev/rules.d` or `/usr/lib/udev/rules.d`, but you may prefer to install it to ```/etc/udev/rules.d``` by hand, if required.
 
 Building on OSX
 ===============

--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ else
     add_project_arguments('-ggdb', language: 'c')
     add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
-    install_data('Support/60-orbcode.rules', install_dir : '/etc/udev/rules.d')
+    install_data('Support/60-orbcode.rules', install_dir : 'lib/udev/rules.d')
     install_data('Support/gdbtrace.init', install_dir : 'share/orbcode')
 endif
 


### PR DESCRIPTION
udev looks in:
 /usr/lib/udev/rules.d
 /usr/local/lib/udev/rules.d
 /run/udev/rules.d
 /etc/udev/rules.d

With meson defaults, (no prefix) this will now install the rules to /usr/local/lib/udev/rules.d (meson will interactively offer to elevate priveliges for this if needed)

With --prefix=/usr, this will place them in /usr/lib/udev/rules.d, which is suitable for packaging

With --prefix=/somewhereelse/ you get what you expect, and no sudden sudo prompts.