### PR TITLE
Fix clang compilation of libdwarf on macOS 13

### DIFF
--- a/subprojects/libdwarf.wrap
+++ b/subprojects/libdwarf.wrap
@@ -5,4 +5,4 @@ source_url = https://www.prevanders.net/libdwarf-0.7.0.tar.xz
 source_filename = libdwarf-0.7.0.tar.xz
 source_hash = 23b71829de875fa5842e49f232c8ee1a5043805749738bc61424d9abc1189f38
 
-diff_files = ./libdwarf/0001-fix-Use-project_source_root-for-subproject-compatibi.patch
+diff_files = ./libdwarf/0001-fix-Use-project_source_root-for-subproject-compatibi.patch, ./libdwarf/0002-fix-compilation-clang.patch

--- a/subprojects/packagefiles/libdwarf/0002-fix-compilation-clang.patch
+++ b/subprojects/packagefiles/libdwarf/0002-fix-compilation-clang.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index 83ecd99..4d3fb4e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -84,6 +84,10 @@ libdwarf_args = [ '-D__USE_MINGW_ANSI_STDIO=0' ]
+ if cc.get_id() == 'msvc'
+   libdwarf_args += [ '-D_CRT_NONSTDC_NO_WARNINGS', '-D_CRT_SECURE_NO_WARNINGS' ]
+ endif
++if cc.get_id() == 'clang'
++  add_project_arguments('-Wno-error=unused-but-set-variable', language: 'c')
++  add_project_arguments('-Wno-error=strict-prototypes', language: 'c')
++endif
+ 
+ config_dir = [include_directories('.')]
+ 


### PR DESCRIPTION
On macOS 13.6 libdwarf does not compile due to some default compile flags.
This patch simply disables them for clang.

```
$ clang --version
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```