### PR TITLE
orbtop: Fix CPU usage growth over time

### DIFF
--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -356,7 +356,7 @@ void _handleSW( struct ITMDecoder *i, struct ITMPacket *p )
 // Outputter routines
 // ====================================================================================================
 // ====================================================================================================
-uint32_t _consolodateReport( struct reportLine **returnReport, uint32_t *returnReportLines )
+uint32_t _consolidateReport( struct reportLine **returnReport, uint32_t *returnReportLines )
 
 {
     struct nameEntry *n;
@@ -1401,7 +1401,7 @@ int main( int argc, char *argv[] )
             if ( receiveResult == RECEIVE_RESULT_TIMEOUT || remainTime <= 0 )
             {
                 /* Create the report that we will output */
-                total = _consolodateReport( &report, &reportLines );
+                total = _consolidateReport( &report, &reportLines );
 
                 if ( options.json )
                 {

--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -1415,6 +1415,8 @@ int main( int argc, char *argv[] )
 
                 /* ... and we are done with the report now, get rid of it */
                 free( report );
+                /* and, the hash of seen addresses! */
+                _flushHash();
 
                 /* ...and zero the exception records */
                 for ( uint32_t e = 0; e < MAX_EXCEPTIONS; e++ )


### PR DESCRIPTION
Tested over 45 minutes, cpu usage stays below 5% the whole time.  Orbtop output still consistent.