### PR TITLE
loadelf: Fix use-after-free of Dwarf_Die pointer

### DIFF
--- a/Src/loadelf.c
+++ b/Src/loadelf.c
@@ -595,10 +595,11 @@ static bool _readLines( struct symbol *p )
 
         dwarf_lowpc( cu_die, &cu_low_addr, 0 );
         _processDie( p, dbg, cu_die, 0, filenameN, producerN, cu_low_addr );
-        dwarf_dealloc( dbg, cu_die, DW_DLA_DIE );
 
         /* ...and the source lines */
         _getSourceLines( p, dbg, cu_die );
+
+        dwarf_dealloc( dbg, cu_die, DW_DLA_DIE );
     }
 
     /* 2: We have the lines and functions. Clean them up and interlink them so they're useful to applications */


### PR DESCRIPTION
This fixes a crash on macOS in loadelf.c that was preventing orbmortem to work with cryptic error messages:

```
 $ orbmortem -e ofiles/simple.elf

libdwarf is unable to record error DW_DLE_DIE_NO_CU_CONTEXT (104) No error argument or handler available

libdwarf is unable to record error DW_DLE_DIE_NO_CU_CONTEXT (104) No error argument or handler available

libdwarf is unable to record error DW_DLE_DIE_NO_CU_CONTEXT (104) No error argument or handler available
No lines found in file
Elf file or symbols in it not found
```

