### PR TITLE
Fix symbolsAquire and add linkage name to get mangled C++ function names

### DIFF
--- a/Inc/loadelf.h
+++ b/Inc/loadelf.h
@@ -125,7 +125,7 @@ char *symbolDisassembleLine( struct symbol *p, enum instructionClass *ic, symbol
 void symbolDelete( struct symbol *p );
 
 /* Collect symbol set with specified components */
-struct symbol *symbolAquire( char *filename, bool loadmem, bool loadsource );
+struct symbol *symbolAcquire( char *filename, bool loadmem, bool loadsource );
 
 /* Check if current symbols are valid */
 bool symbolSetValid( struct symbol *p );

--- a/Src/loadelf.c
+++ b/Src/loadelf.c
@@ -347,7 +347,7 @@ static void _processFunctionDie( struct symbol *p, Dwarf_Debug dbg, Dwarf_Die di
     char *name = NULL;
     Dwarf_Addr h = 0;
     Dwarf_Addr l = 0;
-    enum Dwarf_Form_Class formclass;
+    enum Dwarf_Form_Class formclass = DW_FORM_CLASS_UNKNOWN;
 
     Dwarf_Attribute attr_data;
     Dwarf_Half attr_tag;

--- a/Src/loadelf.c
+++ b/Src/loadelf.c
@@ -1102,7 +1102,7 @@ bool symbolSetValid( struct symbol *p )
 
 // ====================================================================================================
 
-struct symbol *symbolAquire( char *filename, bool loadmem, bool loadsource )
+struct symbol *symbolAcquire( char *filename, bool loadmem, bool loadsource )
 
 /* Collect symbol set with specified components */
 
@@ -1237,11 +1237,7 @@ void main( int argc, char *argv[] )
 
 {
     enum instructionClass ic;
-<<<<<<< HEAD
-    struct symbol *p = symbolAcquire( argv[1], true, true, true );
-=======
-    struct symbol *p = symbolAquire( argv[1], true, true );
->>>>>>> loadelf_fixup
+    struct symbol *p = symbolAcquire( argv[1], true, true );
 
     if ( !p )
     {

--- a/Src/loadelf.c
+++ b/Src/loadelf.c
@@ -384,7 +384,12 @@ static void _processFunctionDie( struct symbol *p, Dwarf_Debug dbg, Dwarf_Die di
 
     specification_die = die;
 
-    if ( DW_DLV_OK != dwarf_diename( die, &name, 0 ) )
+    /* Get the possibly mangled linkage name if it exists */
+    if ( DW_DLV_OK == dwarf_attr( die, DW_AT_linkage_name, &attr_data, 0) )
+    {
+        dwarf_formstring( attr_data, &name, 0 );
+    }
+    else if ( DW_DLV_OK != dwarf_diename( die, &name, 0 ) )
     {
         /* Name will be hidden in a specification reference */
         attr_tag = DW_AT_specification;

--- a/Src/orbmortem.c
+++ b/Src/orbmortem.c
@@ -998,7 +998,7 @@ static bool _dumpBuffer( struct RunTime *r )
     {
         symbolDelete( r->s );
 
-        if ( !( r->s = symbolAquire( r->options->elffile, true, true ) ) )
+        if ( !( r->s = symbolAcquire( r->options->elffile, true, true ) ) )
         {
             genericsReport( V_ERROR, "Elf file or symbols in it not found" EOL );
             return false;
@@ -1270,7 +1270,7 @@ int main( int argc, char *argv[] )
     }
 
     /* Check we've got _some_ symbols to start from */
-    _r.s = symbolAquire( _r.options->elffile, true, true );
+    _r.s = symbolAcquire( _r.options->elffile, true, true );
 
     if ( !_r.s )
     {


### PR DESCRIPTION
- symbolsAcquire was renamed to the old wrong name due to merge.
- removed a unresolved merge conflict.
- fixed a compiler warning about uninitialized variables.
- added linkage name to get C++ symbols.

cc @mubes 