### PR TITLE
build: Make libSDL2 optional and only link orblcd against it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,6 @@ dependencies = [
     dependency('threads'),
     dependency('libusb-1.0'),
     dependency('libzmq'),
-    dependency('SDL2'),
     dependency('ncurses', 'ncursesw'),
     dependency('libelf'),
     uicolours_default,
@@ -49,6 +48,11 @@ dependencies += libdwarf
 libcapstone = dependency('capstone', version: '>=4', required: false)
 if not libcapstone.found()
     libcapstone = disabler()
+endif
+
+libSDL2 = dependency('SDL2', required: false)
+if not libSDL2.found()
+    libSDL2 = disabler()
 endif
 
 if host_machine.system() == 'windows'
@@ -227,7 +231,9 @@ executable('orblcd',
         git_version_info_h,
     ],
     include_directories: incdirs,
-    dependencies: dependencies,
+    dependencies: dependencies + [
+        libSDL2,
+    ],
     link_with: liborb,
     install: true,
 )


### PR DESCRIPTION
While building this suite on Windows 10 under Msys2 UCRT64 I encountered that I have to extract libSDL2.dll and carry it in the "redist" archive to be able to run any of resulting binaries on other machines. Also nothing compiled until I installed said libSDL2 via pacman.

Looking at #143 I wrote a small patch, knowing very little meson, which decouples libSDL2 from command-line tools, and that hypothetically allows me to omit both `orblcd` and libSDL2.dll and have smaller redist archives (we don't use orblcd in our development workflows).

This is a follow-up to the discussion from 10 days ago. 
```
$ objdump -p build-gcc12/orblcd | grep NEEDED
  NEEDED               libasan.so.8
  NEEDED               liborb.so.2.1.0
  NEEDED               libSDL2-2.0.so.0
  NEEDED               libc.so.6
$ objdump -p build-gcc12/orbuculum | grep NEEDED
  NEEDED               libasan.so.8
  NEEDED               liborb.so.2.1.0
  NEEDED               libusb-1.0.so.0
  NEEDED               libc.so.6
$ objdump -p build-gcc12/orbtop | grep NEEDED
  NEEDED               libasan.so.8
  NEEDED               liborb.so.2.1.0
  NEEDED               libc.so.6
```
Ignore the libasan, what's important is only needed libraries are linked for each respective tool. I have yet to test this on Windows, so please allow some time before merging.

If ucrt64 actually links more than needed, then I may want to decouple libzmq in a similar way (we don't use orbzmq either). I'm open for discussion whether my meson-fu allows me to tackle that here.