### PR TITLE
Improve handling of slow arriving usb packets

### DIFF
--- a/Src/orbtop.c
+++ b/Src/orbtop.c
@@ -739,10 +739,10 @@ static void _outputTop( uint32_t total, uint32_t reportLines, struct reportLine 
 
     if ( ( _r.lastReportTicks ) && ( lastTime != _r.lastReportus ) )
         genericsPrintf( "Interval = " C_DATA "%" PRIu64 "ms " C_RESET "/ "C_DATA "%" PRIu64 C_RESET " (~" C_DATA "%" PRIu64 C_RESET " Ticks/ms)" EOL,
-                        ( ( lastTime - _r.lastReportus ) + 500 ) / 1000, _r.timeStamp - _r.lastReportTicks, ( ( _r.timeStamp - _r.lastReportTicks ) * 1000 ) / ( lastTime - _r.lastReportus ) );
+                        ( ( lastTime - _r.lastReportus ) ) / 1000, _r.timeStamp - _r.lastReportTicks, ( ( _r.timeStamp - _r.lastReportTicks ) * 1000 ) / ( lastTime - _r.lastReportus ) );
     else
     {
-        genericsPrintf( C_RESET "Interval = " C_DATA "%" PRIu64 C_RESET "ms" EOL, ( ( lastTime - _r.lastReportus ) + 500 ) / 1000 );
+        genericsPrintf( C_RESET "Interval = " C_DATA "%" PRIu64 C_RESET "ms" EOL, ( ( lastTime - _r.lastReportus ) ) / 1000 );
     }
 
     genericsReport( V_INFO, "         Ovf=%3d  ITMSync=%3d TPIUSync=%3d ITMErrors=%3d" EOL,
@@ -1323,12 +1323,11 @@ int main( int argc, char *argv[] )
         /* ...just in case we have any readings from a previous incantation */
         _flushHash( );
 
-        _r.lastReportus = _timestamp();
+        thisTime = _r.lastReportus = _timestamp();
 
         while ( 1 )
         {
-            thisTime = _timestamp();
-            remainTime = ( ( _r.lastReportus + options.displayInterval - thisTime ) ) + 500;
+            remainTime = ( ( _r.lastReportus + options.displayInterval - thisTime ) );
 
             if ( remainTime > 0 )
             {
@@ -1341,6 +1340,8 @@ int main( int argc, char *argv[] )
                 receiveResult = RECEIVE_RESULT_OK;
                 receivedSize = 0;
             }
+
+            thisTime = _timestamp();
 
             if ( receiveResult == RECEIVE_RESULT_ERROR )
             {

--- a/Src/orbtraceIf.c
+++ b/Src/orbtraceIf.c
@@ -27,6 +27,7 @@ static const struct OrbtraceInterfaceType _validDevices[DEVICE_NUM_DEVICES] =
 #define BMP_EP    (0x85)
 
 #define SCRATCH_STRINGLEN (255)
+#define MAX_DESC_FIELDLEN (50)
 
 #define MIN_GENERIC_VOLTAGE_MV (900)
 #define MAX_GENERIC_VOLTAGE_MV (5000)
@@ -124,6 +125,11 @@ static int _compareFunc( const void *vd1, const void *vd2 )
     const struct OrbtraceIfDevice *d1 = ( const struct OrbtraceIfDevice * )vd1;
     const struct OrbtraceIfDevice *d2 = ( const struct OrbtraceIfDevice * )vd2;
     int r = 0;
+
+    if ( d1->devtype != d2->devtype )
+    {
+        return ( d1->devtype - d2->devtype );
+    }
 
     if ( ( r = _strcmpint( d1->manufacturer, d2->manufacturer ) ) )
     {
@@ -262,6 +268,7 @@ void OrbtraceIfDestroyContext( struct OrbtraceIf *o )
     }
 }
 // ====================================================================================================
+
 int OrbtraceIfGetDeviceList( struct OrbtraceIf *o, char *sn, uint32_t devmask )
 
 /* Get list of devices that match (partial) serial number & devmask */
@@ -392,13 +399,13 @@ void OrbtraceIfListDevices( struct OrbtraceIf *o )
     char printConstruct[SCRATCH_STRINGLEN];
 
     /* Get longest line */
-    genericsPrintf( C_RESET " Id |               Description                |      Serial      |           Version" EOL );
-    genericsPrintf( " ---+------------------------------------------+------------------+----------------------------" EOL );
+    genericsPrintf( C_RESET " Id |                    Description                    |      Serial      |           Version" EOL );
+    genericsPrintf( " ---+---------------------------------------------------+------------------+----------------------------" EOL );
 
     for ( int i = 0; i < o->numDevices; i++ )
     {
-        snprintf( printConstruct, SCRATCH_STRINGLEN, "%s %s", OrbtraceIfGetManufacturer( o, i ), OrbtraceIfGetProduct( o, i ) ) ;
-        genericsPrintf( C_SEL " %2d " C_RESET "|"C_ELEMENT" %-40s "C_RESET"|"C_ELEMENT" %16s "C_RESET"|"C_ELEMENT" %s" C_RESET EOL,
+        snprintf( printConstruct, MAX_DESC_FIELDLEN, "%s %s", OrbtraceIfGetManufacturer( o, i ), OrbtraceIfGetProduct( o, i ) ) ;
+        genericsPrintf( C_SEL " %2d " C_RESET "|"C_ELEMENT" %-49s "C_RESET"|"C_ELEMENT" %16s "C_RESET"|"C_ELEMENT" %s" C_RESET EOL,
                         i + 1, printConstruct, OrbtraceIfGetSN( o, i ), OrbtraceIfGetVersion( o, i ) );
     }
 }
@@ -559,7 +566,7 @@ bool OrbtraceIfSetupTransfers( struct OrbtraceIf *o, bool hiresTime, struct data
                                     USB_TRANSFER_SIZE,
                                     callback,
                                     &o->d[t].usbtfr,
-                                    hiresTime ? 1 : 0 /* Use timeout if hires mode */
+                                    hiresTime ? 1 : 100 /* Use 1ms timeout if hires mode, otherwise 100ms */
                                   );
 
         if ( libusb_submit_transfer( o->d[t].usbtfr ) )

--- a/Src/orbuculum.c
+++ b/Src/orbuculum.c
@@ -367,10 +367,25 @@ void _printHelp( const char *const progName )
 }
 
 // ====================================================================================================
-void _printVersion( void )
+void _printVersion( struct RunTime *r )
 
 {
-    genericsPrintf( "orbuculum version " GIT_DESCRIBE );
+    genericsPrintf( "orbuculum version " GIT_DESCRIBE EOL );
+    r->o = OrbtraceIfCreateContext();
+    int ndevices = OrbtraceIfGetDeviceList( r->o, NULL, DEVTYPE( DEVICE_ORBTRACE_MINI ) | DEVTYPE( DEVICE_BMP ) );
+
+    if ( !ndevices )
+    {
+        genericsPrintf( "No devices found" EOL );
+    }
+    else
+    {
+        genericsPrintf( "Device%s Found;" EOL, ( ndevices > 1 ) ? "s" : "" );
+        OrbtraceIfListDevices( r->o );
+    }
+
+    OrbtraceIfDestroyContext( r->o );
+    r->o = NULL;
 }
 // ====================================================================================================
 static struct option _longOptions[] =
@@ -434,7 +449,7 @@ bool _processOptions( int argc, char *argv[], struct RunTime *r )
 
             // ------------------------------------
             case 'V':
-                _printVersion();
+                _printVersion( r );
                 return false;
 
             // ------------------------------------


### PR DESCRIPTION
Local large buffers for usb packets need to time out at 1s intervals so that orbtop has correct interval data to work with.

Also a trivial change to sort multiple devices by device type ahead of other criteria.