### PR TITLE
Fix C++ function names cut too early

### DIFF
--- a/Src/symbols.c
+++ b/Src/symbols.c
@@ -261,6 +261,11 @@ static enum LineType _getLineType( char *sourceLine, char *p1, char *p2, char *p
     /* If it has something with <xxx> in it, it's a proc label (function) */
     if ( 2 == sscanf( sourceLine, "%[0-9a-fA-F] <%[^>]>", p1, p2 ) )
     {
+        /* Demangled C++ names may have multiple ">" characters. Expand until last one. */
+        const char *const beg = strchr(sourceLine, '<') + 1;
+        const char *const end = strrchr(beg, '>');
+        (void)memcpy(p2, beg, end - beg);
+        p2[end - beg] = '\0';
         return LT_PROC_LABEL;
     }
 


### PR DESCRIPTION
In orbtop some c++ names were cut. For example: `unsigned long& std::__pair_get<1u`, where parsing ended at first `>` occurence, instead of the last.

---

Suggested method here always makes an additional copy but this was safest/easiest way to go forward. Performance hit?