### PR TITLE
Correct local timestamp decoding

### DIFF
--- a/Src/msgDecoder.c
+++ b/Src/msgDecoder.c
@@ -207,17 +207,15 @@ static bool _handleTS( struct ITMPacket *packet, struct TSMsg *decoded )
 
         if ( packet->len > 2 )
         {
-            stamp |= ( packet->d[2] ) << 7;
-
-            if ( packet->len > 3 )
-            {
-                stamp |= ( packet->d[3] & 0x7F ) << 14;
-
-                if ( packet->len > 4 )
-                {
-                    stamp |= ( packet->d[4] & 0x7f ) << 21;
-                }
-            }
+            stamp |= ( packet->d[2] & 0x7F ) << 7;
+        }
+        if ( packet->len > 3 )
+        {
+            stamp |= ( packet->d[3] & 0x7F ) << 14;
+        }
+        if ( packet->len > 4 )
+        {
+            stamp |= ( packet->d[4] & 0x7f ) << 21;
         }
     }
 


### PR DESCRIPTION
The bug was a simple oversight, a missing bitmask, probably due to a copy paste error. Reformatted the three checks to be serial, so the pattern of the code better emerges and differences are easier to spot.

Found this by emitting packages which should occur basically exactly every 250 microseconds (160MHz, 39999 ticks), but orbuculum decoded it to 350 (56383 ticks). The difference is 16384 ticks, so this lead me to the parsing code.