### PR TITLE
Respect the 'forceITMSync' option in orbzmq/orbdump

### DIFF
--- a/Src/orbdump.c
+++ b/Src/orbdump.c
@@ -361,7 +361,8 @@ int main( int argc, char *argv[] )
 
     genericsScreenHandling( !options.mono );
 
-    /* Reset the OFLOW handler before we start */
+    /* Reset the handlers before we start */
+    ITMDecoderInit( &_r.i, options.forceITMSync );
     OFLOWInit( &_r.c );
     stream = _tryOpenStream();
 

--- a/Src/orbzmq.c
+++ b/Src/orbzmq.c
@@ -911,7 +911,8 @@ int main( int argc, char *argv[] )
     _r.zmqSocket = zmq_socket( _r.zmqContext, ZMQ_PUB );
     zmq_bind( _r.zmqSocket, "tcp://*:3442" ); //options.bindUrl );
 
-    /* Reset the OFLOW handler before we start */
+    /* Reset the handlers before we start */
+    ITMDecoderInit( &_r.i, options.forceITMSync );
     OFLOWInit( &_r.c );
 
     /* This ensures the signal handler gets called */


### PR DESCRIPTION
Commit 9761c75f68538d5758bcb347825143532b56e84c removed TPIU-related functions from the code, but also removed ITM Decoder initialization in `orbzmq` and `orbdump`. The ITM decoder is not initialized properly using `ITMDecoderInit()`, which means that the `forceITMSync` parameter is completely ignored. As a result, `orbzmq` and `orbdump` do not work without ITM sync packets, while the rest of the tools work without sync packets as expected. 

This PR fixes the issue and both `orbzmq` and `orbdump` respect the `--itm-sync` option.